### PR TITLE
Allow passing existing `Field`s to `fields`

### DIFF
--- a/docs/source/news.rst
+++ b/docs/source/news.rst
@@ -4,7 +4,7 @@ What's New
 0.7.0
 ^^^^^
 
- * Support positional ``Field``-instance arguments to ``fields()`` to make combining existing field types and simple fields more convenient.
+ * Support positional ``Field``-instance arguments to ``fields()`` to make combining existing field types and simple fields more convenient. Contributed by Jonathan Jacobs.
 
 
 0.6.0

--- a/docs/source/news.rst
+++ b/docs/source/news.rst
@@ -1,6 +1,12 @@
 What's New
 ==========
 
+0.7.0
+^^^^^
+
+ * Support positional ``Field``-instance arguments to ``fields()`` to make combining existing field types and simple fields more convenient.
+
+
 0.6.0
 ^^^^^
 

--- a/docs/source/types.rst
+++ b/docs/source/types.rst
@@ -115,6 +115,17 @@ The equivalent to the code above is:
     LOG_USER_REGISTRATION = MessageType(u"yourapp:authentication:registration",
                                         fields(username=str, age=int))
 
+Or you can even use existing ``Field`` instances with ``fields``:
+
+.. code-block:: python
+
+    from eliot import MessageType, Field, fields
+
+    USERNAME = Field.for_types("username", [str])
+
+    LOG_USER_REGISTRATION = MessageType(u"yourapp:authentication:registration",
+                                        fields(USERNAME, age=int))
+
 Given a ``MessageType`` you can create a ``Message`` instance with the ``message_type`` field pre-populated.
 You can then use it the way you would normally use ``Message``, e.g. ``bind()`` or ``write()``.
 

--- a/eliot/_validation.py
+++ b/eliot/_validation.py
@@ -188,7 +188,12 @@ class _MessageSerializer(object):
         L{Field}.
     """
     def __init__(self, fields):
-        keys = [field.key for field in fields]
+        keys = []
+        for field in fields:
+            if not isinstance(field, Field):
+                raise TypeError(
+                    'Expected a Field instance but got', field)
+            keys.append(field.key)
         if len(set(keys)) != len(keys):
             raise ValueError(keys, "Duplicate field name")
         if "action_type" in keys:

--- a/eliot/_validation.py
+++ b/eliot/_validation.py
@@ -156,16 +156,19 @@ class Field(object):
 
 
 
-def fields(**keys):
+def fields(*fields, **keys):
     """
     Factory for for L{MessageType} and L{ActionType} field definitions.
+
+    @param *fields: A L{tuple} of L{Field} instances.
 
     @param **keys: A L{dict} mapping key names to the expected type of the
         field's values.
 
     @return: A L{list} of L{Field} instances.
     """
-    return [Field.forTypes(key, [value], "") for key, value in keys.items()]
+    return list(fields) + [
+        Field.forTypes(key, [value], "") for key, value in keys.items()]
 
 
 

--- a/eliot/tests/test_validation.py
+++ b/eliot/tests/test_validation.py
@@ -395,6 +395,20 @@ class MessageSerializerTests(TestCase):
                                    "extra": 123})
 
 
+    def test_fieldInstances(self):
+        """
+        Fields to L{_MessageSerializer.__init__} should be instances of
+        L{Field}.
+        """
+        a_field = Field('a_key', identity)
+        arg = object()
+        with self.assertRaises(TypeError) as cm:
+            _MessageSerializer([a_field, arg])
+        self.assertEqual(
+            (u'Expected a Field instance but got', arg),
+            cm.exception.args)
+
+
 
 class MessageTypeTests(TestCase):
     """

--- a/eliot/tests/test_validation.py
+++ b/eliot/tests/test_validation.py
@@ -246,6 +246,18 @@ class FieldsTests(TestCase):
     """
     Tests for L{fields}.
     """
+    def test_fields(self):
+        """
+        L{fields} accepts positional arguments of L{Field} instances and
+        combines them with fields specied as keyword arguments.
+        """
+        a_field = Field(u'akey', identity)
+        l = fields(a_field, another=str)
+        self.assertEqual(
+            {(type(field), field.key) for field in l},
+            {(Field, 'akey'), (Field, 'another')})
+
+
     def test_keys(self):
         """
         L{fields} creates L{Field} instances with the given keys.

--- a/eliot/tests/test_validation.py
+++ b/eliot/tests/test_validation.py
@@ -246,7 +246,7 @@ class FieldsTests(TestCase):
     """
     Tests for L{fields}.
     """
-    def test_fields(self):
+    def test_positional(self):
         """
         L{fields} accepts positional arguments of L{Field} instances and
         combines them with fields specied as keyword arguments.

--- a/eliot/tests/test_validation.py
+++ b/eliot/tests/test_validation.py
@@ -253,6 +253,7 @@ class FieldsTests(TestCase):
         """
         a_field = Field(u'akey', identity)
         l = fields(a_field, another=str)
+        self.assertIn(a_field, l)
         self.assertEqual(
             {(type(field), field.key) for field in l},
             {(Field, 'akey'), (Field, 'another')})


### PR DESCRIPTION
Pull request for issue #144.

I'm not sure if there should be some checking of the positional arguments to `fields`, making sure they're `Field` instances or such?