### PR TITLE
Rip out ``system`` argument to traceback functions

### DIFF
--- a/docs/source/messages.rst
+++ b/docs/source/messages.rst
@@ -53,10 +53,4 @@ You can also log tracebacks when your code hits an unexpected exception:
             try:
                  dosomething()
             except:
-                 write_traceback(self.logger, u"yourapp:yourclass")
-
-The final argument to ``write_traceback`` is the "system".
-This should be a Unicode string, a logical description of what subsystem in your application generated the message.
-Colons are used as namespace separators by convention to discourage the use of Python modules and namespaces.
-System strings should involve code structure rather than file structure.
-This means they will not have to change if you decide to refactor your implementation.
+                 write_traceback(self.logger)

--- a/docs/source/news.rst
+++ b/docs/source/news.rst
@@ -4,8 +4,10 @@ What's New
 0.7.0
 ^^^^^
 
- * Support positional ``Field``-instance arguments to ``fields()`` to make combining existing field types and simple fields more convenient. Contributed by Jonathan Jacobs.
-
+* Support positional ``Field``-instance arguments to ``fields()`` to make combining existing field types and simple fields more convenient.
+  Contributed by Jonathan Jacobs.
+* ``write_traceback`` and ``writeFailure`` no longer require a ``system`` argument, as the combination of traceback and action context should suffice to discover the origin of the problem.
+  This is a minor change to output format as the field is also omitted from the resulting ``eliot:traceback`` messages.
 
 0.6.0
 ^^^^^

--- a/docs/source/twisted.rst
+++ b/docs/source/twisted.rst
@@ -44,7 +44,7 @@ Logging Failures
 
         def run(self):
             d = dosomething()
-            d.addErrback(writeFailure, self.logger, u"yourapp:yourclass")
+            d.addErrback(writeFailure, self.logger)
 
 
 Actions and Deferreds

--- a/eliot/_output.py
+++ b/eliot/_output.py
@@ -161,7 +161,7 @@ class Logger(object):
                 serializer.serialize(dictionary)
             self._destinations.send(dictionary)
         except:
-            writeTraceback(self, "eliot:output")
+            writeTraceback(self)
             msg = Message({"message_type": "eliot:serialization_failure",
                            "message": self._safeUnicodeDictionary(dictionary)})
             msg.write(self)

--- a/eliot/tests/test_output.py
+++ b/eliot/tests/test_output.py
@@ -158,7 +158,7 @@ class MemoryLoggerTests(TestCase):
         try:
             raise exception
         except:
-            writeTraceback(logger, "mytest")
+            writeTraceback(logger)
 
 
     def test_tracebacksCauseTestFailure(self):

--- a/eliot/tests/test_testing.py
+++ b/eliot/tests/test_testing.py
@@ -490,7 +490,7 @@ class ValidateLoggingTests(TestCase):
                 try:
                     1 / 0
                 except ZeroDivisionError:
-                    writeTraceback(logger, "atest")
+                    writeTraceback(logger)
         test = MyTest()
         self.assertRaises(UnflushedTracebacks, test.debug)
 
@@ -573,7 +573,7 @@ class ValidateLoggingTests(TestCase):
                 try:
                     1 / 0
                 except ZeroDivisionError:
-                    writeTraceback(logger, "atest")
+                    writeTraceback(logger)
         test = MyTest()
         test.debug()
         self.assertTrue(test.flushed)

--- a/eliot/tests/test_twisted.py
+++ b/eliot/tests/test_twisted.py
@@ -569,7 +569,7 @@ class RedirectLogsForTrialTests(TestCase):
             raiser()
         except Exception:
             expectedTraceback = traceback.format_exc()
-            writeTraceback(logger, "some:system")
+            writeTraceback(logger)
 
         lines = expectedTraceback.split("\n")
         # Remove source code lines:


### PR DESCRIPTION
Fix #147.