### PR TITLE
Validate logging skip interaction 153

### DIFF
--- a/docs/source/news.rst
+++ b/docs/source/news.rst
@@ -8,6 +8,7 @@ What's New
   Contributed by Jonathan Jacobs.
 * ``write_traceback`` and ``writeFailure`` no longer require a ``system`` argument, as the combination of traceback and action context should suffice to discover the origin of the problem.
   This is a minor change to output format as the field is also omitted from the resulting ``eliot:traceback`` messages.
+* The ``validate_logging`` testing utility now skips validation when the decorated test method raises ``SkipTest``.
 
 0.6.0
 ^^^^^

--- a/eliot/testing.py
+++ b/eliot/testing.py
@@ -4,6 +4,7 @@ Utilities to aid unit testing L{eliot} and code that uses it.
 
 from __future__ import unicode_literals
 
+from unittest import SkipTest
 from collections import namedtuple
 from functools import wraps
 
@@ -257,6 +258,8 @@ def validateLogging(assertion, *assertionArgs, **assertionKwargs):
     def decorator(function):
         @wraps(function)
         def wrapper(self, *args, **kwargs):
+            skipped = False
+
             kwargs["logger"] = logger = MemoryLogger()
             self.addCleanup(logger.validate)
             def checkForUnflushed():
@@ -266,9 +269,14 @@ def validateLogging(assertion, *assertionArgs, **assertionKwargs):
             # TestCase runs cleanups in reverse order, and we want this to
             # run *before* tracebacks are checked:
             if assertion is not None:
-                self.addCleanup(lambda: assertion(
+                self.addCleanup(lambda: skipped or assertion(
                     self, logger, *assertionArgs, **assertionKwargs))
-            return function(self, *args, **kwargs)
+            try:
+                return function(self, *args, **kwargs)
+            except SkipTest:
+                skipped = True
+                raise
+
         return wrapper
     return decorator
 

--- a/eliot/testing.py
+++ b/eliot/testing.py
@@ -263,7 +263,7 @@ def validateLogging(assertion, *assertionArgs, **assertionKwargs):
             kwargs["logger"] = logger = MemoryLogger()
             self.addCleanup(logger.validate)
             def checkForUnflushed():
-                if logger.tracebackMessages:
+                if not skipped and logger.tracebackMessages:
                     raise UnflushedTracebacks(logger.tracebackMessages)
             self.addCleanup(checkForUnflushed)
             # TestCase runs cleanups in reverse order, and we want this to

--- a/eliot/tests/test_testing.py
+++ b/eliot/tests/test_testing.py
@@ -4,7 +4,7 @@ Tests for L{eliot.testing}.
 
 from __future__ import unicode_literals
 
-from unittest import TestCase
+from unittest import SkipTest, TestResult, TestCase
 
 from ..testing import (
     issuperset, assertContainsFields, LoggedAction, LoggedMessage,
@@ -578,6 +578,23 @@ class ValidateLoggingTests(TestCase):
         test.debug()
         self.assertTrue(test.flushed)
 
+
+    def test_validationNotRunForSkip(self):
+        """
+        If the decorated test raises L{SkipTest} then the logging validation is
+        also skipped.
+        """
+        class MyTest(TestCase):
+            def record(self, logger):
+                self.recorded = True
+
+            @validateLogging(record)
+            def runTest(self, logger):
+                raise SkipTest("Do not run this test.")
+
+        test = MyTest()
+        test.run(TestResult())
+        self.assertFalse(test.recorded)
 
 
 MESSAGE1 = MessageType("message1", [Field.forTypes("x", [int], "A number")],

--- a/eliot/tests/test_testing.py
+++ b/eliot/tests/test_testing.py
@@ -606,6 +606,34 @@ class ValidateLoggingTests(TestCase):
         )
 
 
+    def test_unflushedTracebacksDontFailForSkip(self):
+        """
+        If the decorated test raises L{SkipTest} then the unflushed traceback
+        checking normally implied by L{validateLogging} is also skipped.
+        """
+        class MyTest(TestCase):
+
+            @validateLogging(lambda self, logger: None)
+            def runTest(self, logger):
+                try:
+                    1 / 0
+                except:
+                    writeTraceback(logger)
+                raise SkipTest("Do not run this test.")
+
+        test = MyTest()
+        result = TestResult()
+        test.run(result)
+
+        # Verify that there was only a skip, no additional errors or failures
+        # reported.
+        self.assertEqual(
+            (1, [], []),
+            (len(result.skipped), result.errors, result.failures)
+        )
+
+
+
 MESSAGE1 = MessageType("message1", [Field.forTypes("x", [int], "A number")],
                        "A message for testing.")
 MESSAGE2 = MessageType("message2", [], "A message for testing.")

--- a/eliot/tests/test_testing.py
+++ b/eliot/tests/test_testing.py
@@ -585,6 +585,8 @@ class ValidateLoggingTests(TestCase):
         also skipped.
         """
         class MyTest(TestCase):
+            recorded = False
+
             def record(self, logger):
                 self.recorded = True
 
@@ -593,8 +595,15 @@ class ValidateLoggingTests(TestCase):
                 raise SkipTest("Do not run this test.")
 
         test = MyTest()
-        test.run(TestResult())
-        self.assertFalse(test.recorded)
+        result = TestResult()
+        test.run(result)
+
+        # Verify that the validation function did not run and that the test was
+        # nevertheless marked as a skip with the correct reason.
+        self.assertEqual(
+            (test.recorded, result.skipped),
+            (False, [(test, "Do not run this test.")])
+        )
 
 
 MESSAGE1 = MessageType("message1", [Field.forTypes("x", [int], "A number")],

--- a/eliot/tests/test_testing.py
+++ b/eliot/tests/test_testing.py
@@ -601,8 +601,8 @@ class ValidateLoggingTests(TestCase):
         # Verify that the validation function did not run and that the test was
         # nevertheless marked as a skip with the correct reason.
         self.assertEqual(
-            (test.recorded, result.skipped),
-            (False, [(test, "Do not run this test.")])
+            (test.recorded, result.skipped, result.errors, result.failures),
+            (False, [(test, "Do not run this test.")], [], [])
         )
 
 


### PR DESCRIPTION
Fixes #153 

This only handles the synchronous case.  If someone is using `@validateLogging` with Twisted and returns a `Deferred` from their test method ... well, things get harder.  Maybe that case is worth fixing too but maybe it's worth fixing *separately*.

I also disabled unflushed traceback checking for skipped tests on the grounds that if your validation function does not run there's a reasonable chance there could be a traceback you expected to be logged and then get flushed - but you didn't get a chance to flush it.