### PR TITLE
Log JSON when redirecting trial output

### DIFF
--- a/docs/source/news.rst
+++ b/docs/source/news.rst
@@ -5,6 +5,7 @@ What's New
 ^^^^^
 
 * ``Message.log`` will log a new message, combining the existing ``Message.new`` and ``Message.write``.
+* The logs written with ``redirectLogsForTrial`` are now written in JSON format, rather than with ``pformat``.
 
 0.7.0
 ^^^^^

--- a/eliot/tests/test_twisted.py
+++ b/eliot/tests/test_twisted.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, unicode_literals, print_function
 import traceback
 import sys
 from functools import wraps
-from pprint import pformat
+import json
 
 try:
     from twisted.internet.defer import Deferred, succeed, fail
@@ -551,7 +551,7 @@ class RedirectLogsForTrialTests(TestCase):
         logger = Logger()
         Message.new(x=123, y=456).write(logger)
         self.assertEqual(writtenToTwisted,
-                         ["ELIOT: %s" % (pformat(written[0]),)])
+                         ["ELIOT: %s" % (json.dumps(written[0]),)])
 
 
     def test_tracebackMessages(self):
@@ -577,7 +577,7 @@ class RedirectLogsForTrialTests(TestCase):
             [l for l in lines if not l.startswith("    ")])
 
         self.assertEqual(writtenToTwisted,
-                         ["ELIOT: %s" % (pformat(written[0]),),
+                         ["ELIOT: %s" % (json.dumps(written[0]),),
                           "ELIOT Extracted Traceback:\n%s" % (expectedTraceback,)
                       ])
 

--- a/eliot/twisted.py
+++ b/eliot/twisted.py
@@ -4,9 +4,10 @@ APIs for using Eliot from Twisted.
 
 from __future__ import absolute_import, unicode_literals
 
+import json
 import os
 import sys
-from pprint import pformat
+
 
 from twisted.python import log
 from twisted.python.failure import Failure
@@ -202,7 +203,7 @@ class _RedirectLogsForTrial(object):
         @param message: A rendered Eliot message.
         @type message: L{dict}
         """
-        self._log.msg("ELIOT: " + pformat(message))
+        self._log.msg("ELIOT: " + json.dumps(message))
         if message.get("message_type") == "eliot:traceback":
             self._log.msg("ELIOT Extracted Traceback:\n" + message["traceback"])
 


### PR DESCRIPTION
#168 talks about logging JSON when redirecting trial output. It proposes a fuller, better solution, which is having a "pure" eliot log. This patch is an interim step: it does what the current logging does, except it formats it with `json.dumps` rather than `pformat`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/eliot/179)
<!-- Reviewable:end -->
