### PR TITLE
Reversible logging for messages

### DIFF
--- a/eliot/_message.py
+++ b/eliot/_message.py
@@ -63,7 +63,7 @@ class Message(object):
             L{eliot.Logger} may choose to serialize the message. If you're
             using L{eliot.MessageType} this will be populated for you.
         """
-        self._contents = contents
+        self._contents = pmap(contents)
         self._serializer = serializer
 
 
@@ -72,16 +72,14 @@ class Message(object):
         Return a new L{Message} with this message's contents plus the
         additional given bindings.
         """
-        contents = self.contents()
-        contents.update(fields)
-        return Message(contents, self._serializer)
+        return Message(dict(self._contents.update(fields)), self._serializer)
 
 
     def contents(self):
         """
         Return a copy of L{Message} contents.
         """
-        return self._contents.copy()
+        return dict(self._contents)
 
 
     def _timestamp(self):
@@ -105,7 +103,7 @@ class Message(object):
             timestamp=self._timestamp(),
             task_uuid=action._identification["task_uuid"],
             task_level=action._nextTaskLevel(),
-            contents=pmap(self._contents),
+            contents=self._contents,
         )
 
 
@@ -139,7 +137,7 @@ class WrittenMessage(PClass):
     @ivar timestamp: The Unix timestamp of when the message was logged.
     @ivar task_uuid: The UUID of the task in which the message was logged.
     @ivar task_level: The L{TaskLevel} of this message appears within the task.
-    @ivar contents: A C{dict}, the message contents without Eliot metadata.
+    @ivar contents: A C{pmap}, the message contents without Eliot metadata.
     """
 
     timestamp = field()

--- a/eliot/_message.py
+++ b/eliot/_message.py
@@ -94,7 +94,7 @@ class Message(object):
         """
         Freeze this message for logging, registring it with C{action}.
 
-        :rtype: L{LoggedMessage}
+        @rtype: L{LoggedMessage}
         """
         if action is None:
             action = currentAction()
@@ -123,8 +123,10 @@ class Message(object):
             C{None}, the L{Action} will be deduced from the current call
             stack.
         """
+        if logger is None:
+            logger = _output._DEFAULT_LOGGER
         logged = self._freeze(action=action)
-        logged.write(self._serializer, logger=logger)
+        logger.write(logged.asDict(), self._serializer)
         return logged
 
 
@@ -132,7 +134,12 @@ class Message(object):
 class LoggedMessage(namedtuple('LoggedMessage', (
         'timestamp', 'task_uuid', 'task_level', 'contents'))):
     """
-    A L{Message} that has been logged to disk.
+    A L{Message} that has been logged.
+
+    @ivar timestamp: The Unix timestamp of when the message was logged.
+    @ivar task_uuid: The UUID of the task in which the message was logged.
+    @ivar task_level: Where this message appears within the task.
+    @ivar contents: A C{dict}, the message contents without Eliot metadata.
     """
 
     @classmethod
@@ -140,8 +147,8 @@ class LoggedMessage(namedtuple('LoggedMessage', (
         """
         Reconstruct a L{LoggedMessage} from a logged dictionary.
 
-        :param loggedDictionary: A dict representing a parsed log entry.
-        :return: A L{LoggedMessage} for that dictionary.
+        @param loggedDictionary: A dict representing a parsed log entry.
+        @return: A L{LoggedMessage} for that dictionary.
         """
         contents = loggedDictionary.copy()
         timestamp = contents.pop('timestamp')
@@ -161,12 +168,6 @@ class LoggedMessage(namedtuple('LoggedMessage', (
             'task_level': self.task_level,
         })
         return result
-
-
-    def write(self, serializer, logger=None):
-        if logger is None:
-            logger = _output._DEFAULT_LOGGER
-        logger.write(self.asDict(), serializer)
 
 
 

--- a/eliot/_message.py
+++ b/eliot/_message.py
@@ -125,7 +125,6 @@ class Message(object):
             logger = _output._DEFAULT_LOGGER
         logged_dict = self._freeze(action=action)
         logger.write(dict(logged_dict), self._serializer)
-        return WrittenMessage.from_dict(logged_dict)
 
 
 

--- a/eliot/_message.py
+++ b/eliot/_message.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 import time
 from uuid import uuid4
 
-from pyrsistent import PClass, field
+from pyrsistent import PClass, field, pmap
 
 
 class Message(object):
@@ -105,7 +105,7 @@ class Message(object):
             timestamp=self._timestamp(),
             task_uuid=action._identification["task_uuid"],
             task_level=action._nextTaskLevel(),
-            contents=self._contents.copy(),
+            contents=pmap(self._contents),
         )
 
 
@@ -162,17 +162,16 @@ class WrittenMessage(PClass):
         return cls(timestamp=timestamp,
                    task_uuid=task_uuid,
                    task_level=task_level,
-                   contents=contents)
+                   contents=pmap(contents))
 
 
     def asDict(self):
-        result = self.contents.copy()
-        result.update({
+        return dict(self.contents.update({
             'timestamp': self.timestamp,
             'task_uuid': self.task_uuid,
             'task_level': self.task_level.level,
-        })
-        return result
+        }))
+
 
 
 

--- a/eliot/_message.py
+++ b/eliot/_message.py
@@ -93,6 +93,10 @@ class Message(object):
         """
         Freeze this message for logging, registering it with C{action}.
 
+        @param action: The L{Action} which is the context for this message. If
+            C{None}, the L{Action} will be deduced from the current call
+            stack.
+
         @return: A L{PMap} with added C{timestamp}, C{task_uuid}, and
             C{task_level} entries.
         """

--- a/eliot/_message.py
+++ b/eliot/_message.py
@@ -112,9 +112,8 @@ class Message(object):
             action = _defaultAction
         contents = self._contents.copy()
         contents["timestamp"] = self._timestamp()
-        if action is not None:
-            contents["task_uuid"] = action._identification["task_uuid"]
-            contents["task_level"] = action._nextTaskLevel().level
+        contents["task_uuid"] = action._identification["task_uuid"]
+        contents["task_level"] = action._nextTaskLevel().level
         logger.write(contents, self._serializer)
 
 

--- a/eliot/_message.py
+++ b/eliot/_message.py
@@ -94,13 +94,13 @@ class Message(object):
         """
         Freeze this message for logging, registring it with C{action}.
 
-        @rtype: L{LoggedMessage}
+        @rtype: L{WrittenMessage}
         """
         if action is None:
             action = currentAction()
         if action is None:
             action = _defaultAction
-        return LoggedMessage(
+        return WrittenMessage(
             timestamp=self._timestamp(),
             task_uuid=action._identification["task_uuid"],
             task_level=action._nextTaskLevel(),
@@ -131,7 +131,7 @@ class Message(object):
 
 
 
-class LoggedMessage(namedtuple('LoggedMessage', (
+class WrittenMessage(namedtuple('WrittenMessage', (
         'timestamp', 'task_uuid', 'task_level', 'contents'))):
     """
     A L{Message} that has been logged.
@@ -145,10 +145,10 @@ class LoggedMessage(namedtuple('LoggedMessage', (
     @classmethod
     def fromDict(cls, loggedDictionary):
         """
-        Reconstruct a L{LoggedMessage} from a logged dictionary.
+        Reconstruct a L{WrittenMessage} from a logged dictionary.
 
         @param loggedDictionary: A dict representing a parsed log entry.
-        @return: A L{LoggedMessage} for that dictionary.
+        @return: A L{WrittenMessage} for that dictionary.
         """
         contents = loggedDictionary.copy()
         timestamp = contents.pop('timestamp')

--- a/eliot/_message.py
+++ b/eliot/_message.py
@@ -125,7 +125,7 @@ class Message(object):
         if logger is None:
             logger = _output._DEFAULT_LOGGER
         logged = self._freeze(action=action)
-        logger.write(logged.asDict(), self._serializer)
+        logger.write(logged.as_dict(), self._serializer)
         return logged
 
 
@@ -146,14 +146,14 @@ class WrittenMessage(PClass):
     contents = field()
 
     @classmethod
-    def fromDict(cls, loggedDictionary):
+    def from_dict(cls, logged_dictionary):
         """
         Reconstruct a L{WrittenMessage} from a logged dictionary.
 
-        @param loggedDictionary: A dict representing a parsed log entry.
+        @param logged_dictionary: A dict representing a parsed log entry.
         @return: A L{WrittenMessage} for that dictionary.
         """
-        contents = loggedDictionary.copy()
+        contents = logged_dictionary.copy()
         timestamp = contents.pop('timestamp')
         task_uuid = contents.pop('task_uuid')
         task_level = TaskLevel(level=contents.pop('task_level'))
@@ -163,7 +163,7 @@ class WrittenMessage(PClass):
                    contents=pmap(contents))
 
 
-    def asDict(self):
+    def as_dict(self):
         return dict(self.contents.update({
             'timestamp': self.timestamp,
             'task_uuid': self.task_uuid,

--- a/eliot/_message.py
+++ b/eliot/_message.py
@@ -4,6 +4,7 @@ Log messages and related utilities.
 
 from __future__ import unicode_literals
 
+from collections import namedtuple
 import time
 from uuid import uuid4
 
@@ -110,11 +111,28 @@ class Message(object):
             action = currentAction()
         if action is None:
             action = _defaultAction
-        contents = self._contents.copy()
-        contents["timestamp"] = self._timestamp()
-        contents["task_uuid"] = action._identification["task_uuid"]
-        contents["task_level"] = action._nextTaskLevel().level
-        logger.write(contents, self._serializer)
+        logged = LoggedMessage(
+            timestamp=self._timestamp(),
+            task_uuid=action._identification["task_uuid"],
+            task_level=action._nextTaskLevel().level,
+            contents=self._contents.copy(),
+        )
+        logger.write(logged.asDict(), self._serializer)
+        return logged
+
+
+
+class LoggedMessage(namedtuple('LoggedMessage', (
+        'timestamp', 'task_uuid', 'task_level', 'contents'))):
+
+    def asDict(self):
+        result = self.contents.copy()
+        result.update({
+            'timestamp': self.timestamp,
+            'task_uuid': self.task_uuid,
+            'task_level': self.task_level,
+        })
+        return result
 
 
 

--- a/eliot/_message.py
+++ b/eliot/_message.py
@@ -72,7 +72,7 @@ class Message(object):
         Return a new L{Message} with this message's contents plus the
         additional given bindings.
         """
-        return Message(dict(self._contents.update(fields)), self._serializer)
+        return Message(self._contents.update(fields), self._serializer)
 
 
     def contents(self):

--- a/eliot/_message.py
+++ b/eliot/_message.py
@@ -4,9 +4,10 @@ Log messages and related utilities.
 
 from __future__ import unicode_literals
 
-from collections import namedtuple
 import time
 from uuid import uuid4
+
+from pyrsistent import PClass, field
 
 
 class Message(object):
@@ -131,8 +132,7 @@ class Message(object):
 
 
 
-class WrittenMessage(namedtuple('WrittenMessage', (
-        'timestamp', 'task_uuid', 'task_level', 'contents'))):
+class WrittenMessage(PClass):
     """
     A L{Message} that has been logged.
 
@@ -141,6 +141,11 @@ class WrittenMessage(namedtuple('WrittenMessage', (
     @ivar task_level: The L{TaskLevel} of this message appears within the task.
     @ivar contents: A C{dict}, the message contents without Eliot metadata.
     """
+
+    timestamp = field()
+    task_uuid = field()
+    task_level = field()
+    contents = field()
 
     @classmethod
     def fromDict(cls, loggedDictionary):

--- a/eliot/_message.py
+++ b/eliot/_message.py
@@ -103,7 +103,7 @@ class Message(object):
         return LoggedMessage(
             timestamp=self._timestamp(),
             task_uuid=action._identification["task_uuid"],
-            task_level=action._nextTaskLevel().level,
+            task_level=action._nextTaskLevel(),
             contents=self._contents.copy(),
         )
 
@@ -138,7 +138,7 @@ class LoggedMessage(namedtuple('LoggedMessage', (
 
     @ivar timestamp: The Unix timestamp of when the message was logged.
     @ivar task_uuid: The UUID of the task in which the message was logged.
-    @ivar task_level: Where this message appears within the task.
+    @ivar task_level: The L{TaskLevel} of this message appears within the task.
     @ivar contents: A C{dict}, the message contents without Eliot metadata.
     """
 
@@ -153,7 +153,7 @@ class LoggedMessage(namedtuple('LoggedMessage', (
         contents = loggedDictionary.copy()
         timestamp = contents.pop('timestamp')
         task_uuid = contents.pop('task_uuid')
-        task_level = contents.pop('task_level')
+        task_level = TaskLevel(level=contents.pop('task_level'))
         return cls(timestamp=timestamp,
                    task_uuid=task_uuid,
                    task_level=task_level,
@@ -165,7 +165,7 @@ class LoggedMessage(namedtuple('LoggedMessage', (
         result.update({
             'timestamp': self.timestamp,
             'task_uuid': self.task_uuid,
-            'task_level': self.task_level,
+            'task_level': self.task_level.level,
         })
         return result
 

--- a/eliot/_message.py
+++ b/eliot/_message.py
@@ -131,6 +131,27 @@ class Message(object):
 
 class LoggedMessage(namedtuple('LoggedMessage', (
         'timestamp', 'task_uuid', 'task_level', 'contents'))):
+    """
+    A L{Message} that has been logged to disk.
+    """
+
+    @classmethod
+    def fromDict(cls, loggedDictionary):
+        """
+        Reconstruct a L{LoggedMessage} from a logged dictionary.
+
+        :param loggedDictionary: A dict representing a parsed log entry.
+        :return: A L{LoggedMessage} for that dictionary.
+        """
+        contents = loggedDictionary.copy()
+        timestamp = contents.pop('timestamp')
+        task_uuid = contents.pop('task_uuid')
+        task_level = contents.pop('task_level')
+        return cls(timestamp=timestamp,
+                   task_uuid=task_uuid,
+                   task_level=task_level,
+                   contents=contents)
+
 
     def asDict(self):
         result = self.contents.copy()
@@ -140,6 +161,7 @@ class LoggedMessage(namedtuple('LoggedMessage', (
             'task_level': self.task_level,
         })
         return result
+
 
     def write(self, serializer, logger=None):
         if logger is None:

--- a/eliot/_message.py
+++ b/eliot/_message.py
@@ -164,6 +164,11 @@ class WrittenMessage(PClass):
 
 
     def as_dict(self):
+        """
+        Return the dictionary that was used to write this message.
+
+        @return: A C{dict}, as might be logged by Eliot.
+        """
         return dict(self.contents.update({
             'timestamp': self.timestamp,
             'task_uuid': self.task_uuid,

--- a/eliot/tests/test_message.py
+++ b/eliot/tests/test_message.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
     Failure = None
 
-from .._message import LoggedMessage, Message, _defaultAction
+from .._message import WrittenMessage, Message, _defaultAction
 from .._output import MemoryLogger
 from .._action import Action, startAction, TaskLevel
 from .. import add_destination, remove_destination
@@ -197,7 +197,7 @@ class MessageTests(TestCase):
                           "key": 2})
 
 
-    def test_writeReturnsLoggedMessage(self):
+    def test_writeReturnsWrittenMessage(self):
         """
         L{Message.write} returns an object representing the message that it
         logged.
@@ -208,7 +208,7 @@ class MessageTests(TestCase):
         msg = Message.new(key=2)
         result = msg.write(logger, action)
         written = logger.messages[0]
-        expected = LoggedMessage(
+        expected = WrittenMessage(
             timestamp=written['timestamp'],
             task_uuid=written['task_uuid'],
             task_level=TaskLevel(level=written['task_level']),
@@ -269,11 +269,11 @@ class MessageTests(TestCase):
 
 
 
-class FrozenMessageTests(TestCase):
+class WrittenMessageTests(TestCase):
 
     def test_asDict(self):
         contents = {'foo': 'bar'}
-        message = LoggedMessage(
+        message = WrittenMessage(
             timestamp=1,
             task_uuid='unique',
             task_level=TaskLevel(level=[1]),
@@ -295,8 +295,8 @@ class FrozenMessageTests(TestCase):
             'task_level': [1],
             'foo': 'bar',
         }
-        parsed = LoggedMessage.fromDict(log_entry)
-        expected = LoggedMessage(
+        parsed = WrittenMessage.fromDict(log_entry)
+        expected = WrittenMessage(
             timestamp=1,
             task_uuid='unique',
             task_level=TaskLevel(level=[1]),

--- a/eliot/tests/test_message.py
+++ b/eliot/tests/test_message.py
@@ -283,6 +283,23 @@ class FrozenMessageTests(TestCase):
             'timestamp': 1,
             'task_uuid': 'unique',
             'task_level': [1],
-            'foo':  'bar',
+            'foo': 'bar',
         }
         self.assertEqual(message.asDict(), expected)
+
+
+    def test_fromDict(self):
+        log_entry = {
+            'timestamp': 1,
+            'task_uuid': 'unique',
+            'task_level': [1],
+            'foo': 'bar',
+        }
+        parsed = LoggedMessage.fromDict(log_entry)
+        expected = LoggedMessage(
+            timestamp=1,
+            task_uuid='unique',
+            task_level=[1],
+            contents={'foo': 'bar'},
+        )
+        self.assertEqual(parsed, expected)

--- a/eliot/tests/test_message.py
+++ b/eliot/tests/test_message.py
@@ -210,12 +210,7 @@ class MessageTests(TestCase):
         msg = Message.new(key=2)
         result = msg.write(logger, action)
         written = logger.messages[0]
-        expected = WrittenMessage(
-            timestamp=written['timestamp'],
-            task_uuid=written['task_uuid'],
-            task_level=TaskLevel(level=written['task_level']),
-            contents={'key': 2},
-        )
+        expected = WrittenMessage.from_dict(written)
         self.assertEqual(result, expected)
 
 
@@ -281,20 +276,13 @@ class WrittenMessageTests(TestCase):
         L{WrittenMessage.as_dict} returns the dictionary that will be serialized
         to the log.
         """
-        contents = pmap({'foo': 'bar'})
-        message = WrittenMessage(
-            timestamp=1,
-            task_uuid='unique',
-            task_level=TaskLevel(level=[1]),
-            contents=contents,
-        )
-        expected = {
+        log_entry = pmap({
             'timestamp': 1,
             'task_uuid': 'unique',
             'task_level': [1],
             'foo': 'bar',
-        }
-        self.assertEqual(message.as_dict(), expected)
+        })
+        self.assertEqual(WrittenMessage.from_dict(log_entry).as_dict(), log_entry)
 
 
     def test_from_dict(self):
@@ -302,17 +290,14 @@ class WrittenMessageTests(TestCase):
         L{WrittenMessage.from_dict} converts a dictionary that has been
         deserialized from a log into a L{WrittenMessage} object.
         """
-        log_entry = {
+        log_entry = pmap({
             'timestamp': 1,
             'task_uuid': 'unique',
             'task_level': [1],
             'foo': 'bar',
-        }
+        })
         parsed = WrittenMessage.from_dict(log_entry)
-        expected = WrittenMessage(
-            timestamp=1,
-            task_uuid='unique',
-            task_level=TaskLevel(level=[1]),
-            contents={'foo': 'bar'},
-        )
-        self.assertEqual(parsed, expected)
+        self.assertEqual(parsed.timestamp, 1)
+        self.assertEqual(parsed.task_uuid, 'unique')
+        self.assertEqual(parsed.task_level, TaskLevel(level=[1]))
+        self.assertEqual(parsed.contents, pmap({'foo': 'bar'}))

--- a/eliot/tests/test_message.py
+++ b/eliot/tests/test_message.py
@@ -7,6 +7,8 @@ from __future__ import unicode_literals
 from unittest import TestCase
 import time
 
+from pyrsistent import pmap
+
 try:
     from twisted.python.failure import Failure
 except ImportError:
@@ -279,7 +281,7 @@ class WrittenMessageTests(TestCase):
         L{WrittenMessage.asDict} returns the dictionary that will be serialized
         to the log.
         """
-        contents = {'foo': 'bar'}
+        contents = pmap({'foo': 'bar'})
         message = WrittenMessage(
             timestamp=1,
             task_uuid='unique',

--- a/eliot/tests/test_message.py
+++ b/eliot/tests/test_message.py
@@ -270,8 +270,15 @@ class MessageTests(TestCase):
 
 
 class WrittenMessageTests(TestCase):
+    """
+    Tests for L{WrittenMessage}.
+    """
 
     def test_asDict(self):
+        """
+        L{WrittenMessage.asDict} returns the dictionary that will be serialized
+        to the log.
+        """
         contents = {'foo': 'bar'}
         message = WrittenMessage(
             timestamp=1,
@@ -289,6 +296,10 @@ class WrittenMessageTests(TestCase):
 
 
     def test_fromDict(self):
+        """
+        L{WrittenMessage.fromDict} converts a dictionary that has been
+        deserialized from a log into a L{WrittenMessage} object.
+        """
         log_entry = {
             'timestamp': 1,
             'task_uuid': 'unique',

--- a/eliot/tests/test_message.py
+++ b/eliot/tests/test_message.py
@@ -199,21 +199,6 @@ class MessageTests(TestCase):
                           "key": 2})
 
 
-    def test_writeReturnsWrittenMessage(self):
-        """
-        L{Message.write} returns an object representing the message that it
-        logged.
-        """
-        logger = MemoryLogger()
-        action = Action(logger, "unique", TaskLevel(level=[]),
-                        "sys:thename")
-        msg = Message.new(key=2)
-        result = msg.write(logger, action)
-        written = logger.messages[0]
-        expected = WrittenMessage.from_dict(written)
-        self.assertEqual(result, expected)
-
-
     def test_actionCounter(self):
         """
         Each message written within the context of an L{Action} gets its

--- a/eliot/tests/test_message.py
+++ b/eliot/tests/test_message.py
@@ -276,9 +276,9 @@ class WrittenMessageTests(TestCase):
     Tests for L{WrittenMessage}.
     """
 
-    def test_asDict(self):
+    def test_as_dict(self):
         """
-        L{WrittenMessage.asDict} returns the dictionary that will be serialized
+        L{WrittenMessage.as_dict} returns the dictionary that will be serialized
         to the log.
         """
         contents = pmap({'foo': 'bar'})
@@ -294,12 +294,12 @@ class WrittenMessageTests(TestCase):
             'task_level': [1],
             'foo': 'bar',
         }
-        self.assertEqual(message.asDict(), expected)
+        self.assertEqual(message.as_dict(), expected)
 
 
-    def test_fromDict(self):
+    def test_from_dict(self):
         """
-        L{WrittenMessage.fromDict} converts a dictionary that has been
+        L{WrittenMessage.from_dict} converts a dictionary that has been
         deserialized from a log into a L{WrittenMessage} object.
         """
         log_entry = {
@@ -308,7 +308,7 @@ class WrittenMessageTests(TestCase):
             'task_level': [1],
             'foo': 'bar',
         }
-        parsed = WrittenMessage.fromDict(log_entry)
+        parsed = WrittenMessage.from_dict(log_entry)
         expected = WrittenMessage(
             timestamp=1,
             task_uuid='unique',

--- a/eliot/tests/test_message.py
+++ b/eliot/tests/test_message.py
@@ -211,7 +211,7 @@ class MessageTests(TestCase):
         expected = LoggedMessage(
             timestamp=written['timestamp'],
             task_uuid=written['task_uuid'],
-            task_level=written['task_level'],
+            task_level=TaskLevel(level=written['task_level']),
             contents={'key': 2},
         )
         self.assertEqual(result, expected)
@@ -276,7 +276,7 @@ class FrozenMessageTests(TestCase):
         message = LoggedMessage(
             timestamp=1,
             task_uuid='unique',
-            task_level=[1],
+            task_level=TaskLevel(level=[1]),
             contents=contents,
         )
         expected = {
@@ -299,7 +299,7 @@ class FrozenMessageTests(TestCase):
         expected = LoggedMessage(
             timestamp=1,
             task_uuid='unique',
-            task_level=[1],
+            task_level=TaskLevel(level=[1]),
             contents={'foo': 'bar'},
         )
         self.assertEqual(parsed, expected)

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,8 @@ setup(
         "zope.interface",
         # Struct-like objects:
         "characteristic",
+        # Persistent objects for Python:
+        "pyrsistent",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
Adds a new `LoggedMessage` class to `eliot._message`. This class knows how to turn a message into a dict and how to turn a dict into a message. It's an incremental step toward #181. Then next step would be adding something that takes a stream of `LoggedMessage` objects and constructs a `LoggedAction`.

The `LoggedMessage` class dignifies `timestamp`, `task_uuid`, and `task_level` with their own attributes and docstrings. As a late call, I made `task_level` actually be a `TaskLevel` object, to keep up with the "structured data" leitmotif.

The patch also separates figuring out what we should write from the actual writing by adding a `_freeze` method to `Message`.

I've deliberately left `eliot.testing.LoggedMessage` untouched, because I wasn't sure what to do with it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/eliot/182)
<!-- Reviewable:end -->
