### PR TITLE
Make TaskLevel immutable

### DIFF
--- a/eliot/_action.py
+++ b/eliot/_action.py
@@ -126,15 +126,13 @@ class TaskLevel(PClass):
         return TaskLevel(level=self.level.set(-1, self.level[-1] + 1))
 
 
-    def child(self, level=1):
+    def child(self):
         """
         Return a child of this L{TaskLevel}.
 
-        @param int level: Which child to return. Defaults to 1, the first
-            child.
-        @return: L{TaskLevel} which is a child of this one.
+        @return: L{TaskLevel} which is the first child of this one.
         """
-        return TaskLevel(level=self.level.append(level))
+        return TaskLevel(level=self.level.append(1))
 
 
     def parent(self):

--- a/eliot/_action.py
+++ b/eliot/_action.py
@@ -101,9 +101,10 @@ class TaskLevel(PClass):
         return "/" + "/".join(map(unicode, self.level))
 
 
-    def next(self):
+    def next_sibling(self):
         """
-        Return the next L{TaskLevel}.
+        Return the next L{TaskLevel}, that is a task at the same level as this
+        one, but one after.
 
         @return: L{TaskLevel} which follows this one.
         """
@@ -246,7 +247,7 @@ class Action(object):
         if not self._last_child:
             self._last_child = self._task_level.child()
         else:
-            self._last_child = self._last_child.next()
+            self._last_child = self._last_child.next_sibling()
         return self._last_child
 
 

--- a/eliot/_action.py
+++ b/eliot/_action.py
@@ -13,7 +13,7 @@ from itertools import count
 from contextlib import contextmanager
 from warnings import warn
 
-from pyrsistent import PClass, pvector, pvector_field
+from pyrsistent import PClass, pvector_field
 
 from six import text_type as unicode
 

--- a/eliot/_action.py
+++ b/eliot/_action.py
@@ -13,7 +13,7 @@ from itertools import count
 from contextlib import contextmanager
 from warnings import warn
 
-from pyrsistent import pvector
+from pyrsistent import PClass, pvector, pvector_field
 
 from six import text_type as unicode
 
@@ -68,7 +68,7 @@ currentAction = _context.current
 
 
 
-class TaskLevel(object):
+class TaskLevel(PClass):
     """
     The location of a message within the tree of actions of a task.
 
@@ -78,17 +78,7 @@ class TaskLevel(object):
         the second item in the task.
     """
 
-    def __init__(self, level):
-        self.level = pvector(level)
-
-    def __eq__(self, other):
-        return self.level == other.level
-
-    def __ne__(self, other):
-        return not (self == other)
-
-    def __repr__(self):
-        return 'TaskLevel<level=%r>' % (self.level,)
+    level = pvector_field(int)
 
     @classmethod
     def fromString(cls, string):

--- a/eliot/_action.py
+++ b/eliot/_action.py
@@ -76,20 +76,19 @@ class TaskLevel(object):
         relationship, and the value indicates message count. E.g. C{[2,
         3]} indicates this is the third message within an action which is
         the second item in the task.
-
-    @ivar _numberOfMessages: The number of messages created in the context of
-        an action.
     """
 
     def __init__(self, level):
         self.level = pvector(level)
-        self._numberOfMessages = iter(count())
 
     def __eq__(self, other):
         return self.level == other.level
 
     def __ne__(self, other):
         return not (self == other)
+
+    def __repr__(self):
+        return 'TaskLevel<level=%r>' % (self.level,)
 
     @classmethod
     def fromString(cls, string):
@@ -144,19 +143,9 @@ class TaskLevel(object):
         return TaskLevel(level=self.level[:-1])
 
 
-    def nextChild(self):
-        """
-        Return the next child L{TaskLevel}.
-
-        @return: L{TaskLevel} which is child of this one.
-        """
-        return self.child(next(self._numberOfMessages) + 1)
-
-
     # PEP 8 compatibility:
     from_string = fromString
     to_string = toString
-    next_child = nextChild
 
 
 _TASK_ID_NOT_SUPPLIED = object()

--- a/eliot/_action.py
+++ b/eliot/_action.py
@@ -104,7 +104,7 @@ class TaskLevel(PClass):
 
         @return: L{TaskLevel} parsed from the string.
         """
-        return cls(level=pvector([int(i) for i in string.split("/") if i]))
+        return cls(level=[int(i) for i in string.split("/") if i])
 
 
     def toString(self):

--- a/eliot/_action.py
+++ b/eliot/_action.py
@@ -13,6 +13,8 @@ from itertools import count
 from contextlib import contextmanager
 from warnings import warn
 
+from pyrsistent import pvector
+
 from six import text_type as unicode
 
 from ._message import Message
@@ -70,7 +72,7 @@ class TaskLevel(object):
     """
     The location of a message within the tree of actions of a task.
 
-    @ivar level: A list of integers. Each item indicates a child
+    @ivar level: A pvector of integers. Each item indicates a child
         relationship, and the value indicates message count. E.g. C{[2,
         3]} indicates this is the third message within an action which is
         the second item in the task.
@@ -80,7 +82,7 @@ class TaskLevel(object):
     """
 
     def __init__(self, level):
-        self.level = level
+        self.level = pvector(level)
         self._numberOfMessages = iter(count())
 
     def __eq__(self, other):
@@ -98,7 +100,7 @@ class TaskLevel(object):
 
         @return: L{TaskLevel} parsed from the string.
         """
-        return cls(level=[int(i) for i in string.split("/") if i])
+        return cls(level=pvector([int(i) for i in string.split("/") if i]))
 
 
     def toString(self):
@@ -116,7 +118,7 @@ class TaskLevel(object):
 
         @return: L{TaskLevel} which is child of this one.
         """
-        return TaskLevel(level=self.level + [next(self._numberOfMessages) + 1])
+        return TaskLevel(level=self.level.append(next(self._numberOfMessages) + 1))
 
 
     # PEP 8 compatibility:

--- a/eliot/_action.py
+++ b/eliot/_action.py
@@ -80,6 +80,21 @@ class TaskLevel(PClass):
 
     level = pvector_field(int)
 
+    # PClass really ought to provide this ordering facility for us:
+    # tobgu/pyrsistent#45.
+
+    def __lt__(self, other):
+        return self.level < other.level
+
+    def __le__(self, other):
+        return self.level <= other.level
+
+    def __gt__(self, other):
+        return self.level > other.level
+
+    def __ge__(self, other):
+        return self.level >= other.level
+
     @classmethod
     def fromString(cls, string):
         """

--- a/eliot/_action.py
+++ b/eliot/_action.py
@@ -13,8 +13,6 @@ from itertools import count
 from contextlib import contextmanager
 from warnings import warn
 
-from characteristic import attributes
-
 from six import text_type as unicode
 
 from ._message import Message
@@ -68,7 +66,6 @@ currentAction = _context.current
 
 
 
-@attributes(["level"])
 class TaskLevel(object):
     """
     The location of a message within the tree of actions of a task.
@@ -81,9 +78,16 @@ class TaskLevel(object):
     @ivar _numberOfMessages: The number of messages created in the context of
         an action.
     """
-    def __init__(self):
+
+    def __init__(self, level):
+        self.level = level
         self._numberOfMessages = iter(count())
 
+    def __eq__(self, other):
+        return self.level == other.level
+
+    def __ne__(self, other):
+        return not (self == other)
 
     @classmethod
     def fromString(cls, string):

--- a/eliot/_message.py
+++ b/eliot/_message.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 import time
 from uuid import uuid4
 
-from pyrsistent import PClass, field, pmap
+from pyrsistent import PClass, field, pmap, thaw
 
 
 class Message(object):
@@ -107,7 +107,7 @@ class Message(object):
         return self._contents.update({
             'timestamp': self._timestamp(),
             'task_uuid': action._identification['task_uuid'],
-            'task_level': action._nextTaskLevel().level
+            'task_level': thaw(action._nextTaskLevel().level),
         })
 
     def write(self, logger=None, action=None):

--- a/eliot/tests/test_action.py
+++ b/eliot/tests/test_action.py
@@ -818,7 +818,7 @@ class TaskLevelTests(TestCase):
         L{TaskLevel.next} returns the next sibling of a task.
         """
         task = TaskLevel(level=task_level)
-        sibling = task.next()
+        sibling = task.next_sibling()
         self.assertEqual(
             sibling, TaskLevel(level=task_level[:-1] + [task_level[-1] + 1]))
 
@@ -835,7 +835,7 @@ class TaskLevelTests(TestCase):
         L{TaskLevel.toString} serializes the object to a Unicode string.
         """
         root = TaskLevel(level=[])
-        child2_1 = root.child().next().child()
+        child2_1 = root.child().next_sibling().child()
         self.assertEqual([root.toString(), child2_1.toString()],
                          ["/", "/2/1"])
 

--- a/eliot/tests/test_action.py
+++ b/eliot/tests/test_action.py
@@ -801,23 +801,6 @@ class TaskLevelTests(TestCase):
     """
     Tests for L{TaskLevel}.
     """
-    def test_nextChild(self):
-        """
-        L{TaskLevel.nextChild} increments a counter and adds it to the current
-        level.
-        """
-        root = TaskLevel(level=[])
-        child1 = root.nextChild()
-        child2 = root.nextChild()
-        child3 = root.nextChild()
-        child3_1 = child3.nextChild()
-        child3_2 = child3.nextChild()
-        child4 = root.nextChild()
-        self.assertEqual([child1, child2, child3_1, child3_2, child4],
-                         [TaskLevel(level=[1]), TaskLevel(level=[2]),
-                          TaskLevel(level=[3, 1]), TaskLevel(level=[3, 2]),
-                          TaskLevel(level=[4])])
-
 
     @given(lists(TASK_LEVELS), TASK_LEVELS)
     def test_parent_of_child(self, base_task_level, child_level):
@@ -852,8 +835,7 @@ class TaskLevelTests(TestCase):
         L{TaskLevel.toString} serializes the object to a Unicode string.
         """
         root = TaskLevel(level=[])
-        root.nextChild()
-        child2_1 = root.nextChild().nextChild()
+        child2_1 = root.child().next().child()
         self.assertEqual([root.toString(), child2_1.toString()],
                          ["/", "/2/1"])
 
@@ -879,10 +861,3 @@ class TaskLevelTests(TestCase):
         L{TaskLevel.to_string} is the same as as L{TaskLevel.toString}.
         """
         self.assertEqual(TaskLevel.to_string, TaskLevel.toString)
-
-
-    def test_next_child(self):
-        """
-        L{TaskLevel.next_child} is the same as as L{TaskLevel.nextChild}.
-        """
-        self.assertEqual(TaskLevel.next_child, TaskLevel.nextChild)

--- a/eliot/tests/test_action.py
+++ b/eliot/tests/test_action.py
@@ -828,23 +828,23 @@ class TaskLevelTests(TestCase):
         ]))
 
 
-    @given(lists(TASK_LEVELS), TASK_LEVELS)
-    def test_parent_of_child(self, base_task_level, child_level):
+    @given(lists(TASK_LEVELS))
+    def test_parent_of_child(self, base_task_level):
         """
-        L{TaskLevel.child} returns a child task, defaulting to the first child.
+        L{TaskLevel.child} returns the first child of the task.
         """
         base_task = TaskLevel(level=base_task_level)
-        child_task = base_task.child(child_level)
+        child_task = base_task.child()
         self.assertEqual(base_task, child_task.parent())
 
 
-    @given(lists(TASK_LEVELS, min_size=1), TASK_LEVELS)
-    def test_child_greater_than_parent(self, task_level, child_level):
+    @given(lists(TASK_LEVELS, min_size=1))
+    def test_child_greater_than_parent(self, task_level):
         """
         L{TaskLevel.child} returns a child that is greater than its parent.
         """
         task = TaskLevel(level=task_level)
-        self.assert_fully_less_than(task, task.child(child_level))
+        self.assert_fully_less_than(task, task.child())
 
 
     @given(lists(TASK_LEVELS, min_size=1))

--- a/eliot/tests/test_action.py
+++ b/eliot/tests/test_action.py
@@ -813,9 +813,9 @@ class TaskLevelTests(TestCase):
 
 
     @given(lists(TASK_LEVELS, min_size=1))
-    def test_next(self, task_level):
+    def test_next_sibling(self, task_level):
         """
-        L{TaskLevel.next} returns the next sibling of a task.
+        L{TaskLevel.next_sibling} returns the next sibling of a task.
         """
         task = TaskLevel(level=task_level)
         sibling = task.next_sibling()

--- a/eliot/tests/test_action.py
+++ b/eliot/tests/test_action.py
@@ -802,6 +802,32 @@ class TaskLevelTests(TestCase):
     Tests for L{TaskLevel}.
     """
 
+    def assert_fully_less_than(self, x, y):
+        """
+        Assert that x < y according to all the comparison operators.
+        """
+        self.assertTrue(all([
+            # lt
+            x < y,
+            not y < x,
+            # le
+            x <= y,
+            not y <= x,
+            # gt
+            y > x,
+            not x > y,
+            # ge
+            y >= x,
+            not x >= y,
+            # eq
+            not x == y,
+            not y == x,
+            # ne
+            x != y,
+            y != x,
+        ]))
+
+
     @given(lists(TASK_LEVELS), TASK_LEVELS)
     def test_parent_of_child(self, base_task_level, child_level):
         """
@@ -810,6 +836,24 @@ class TaskLevelTests(TestCase):
         base_task = TaskLevel(level=base_task_level)
         child_task = base_task.child(child_level)
         self.assertEqual(base_task, child_task.parent())
+
+
+    @given(lists(TASK_LEVELS, min_size=1), TASK_LEVELS)
+    def test_child_greater_than_parent(self, task_level, child_level):
+        """
+        L{TaskLevel.child} returns a child that is greater than its parent.
+        """
+        task = TaskLevel(level=task_level)
+        self.assert_fully_less_than(task, task.child(child_level))
+
+
+    @given(lists(TASK_LEVELS, min_size=1))
+    def test_next_sibling_greater(self, task_level):
+        """
+        L{TaskLevel.next_sibling} returns a greater task level.
+        """
+        task = TaskLevel(level=task_level)
+        self.assert_fully_less_than(task, task.next_sibling())
 
 
     @given(lists(TASK_LEVELS, min_size=1))

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,8 @@ setup(
         "dev": [
             # Allows us to measure code coverage:
             "coverage",
+            # Bug-seeking missile:
+            "hypothesis",
         ]
     },
     keywords="logging",


### PR DESCRIPTION
Make `TaskLevel` immutable, moving the mutating part up to `Action`, which now knows what the last task it logged was.

Also adds some tests that use `hypothesis`. This slows the test suite a bit (~0.4s on my laptop), because although it looks like I'm adding two tests I'm actually adding two hundred. I'm happy to ditch hypothesis and rewrite them the normal way.

Although not strictly necessary for the parsing work I have planned in #188, this at least helps my thinking about the problem.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/eliot/189)
<!-- Reviewable:end -->
