### PR TITLE
Get rid of the default action

### DIFF
--- a/docs/source/news.rst
+++ b/docs/source/news.rst
@@ -14,6 +14,7 @@ Bug fixes:
 
 * ``FileDestination`` will now call ``flush()`` on the given file object after writing the log message.
   Previously log messages would not end up being written out until the file buffer filled up.
+* Each ``Message`` logged outside the context of an action now gets a unique ``task_id``.
 
 
 0.7.0


### PR DESCRIPTION
Fixes #197.

This means messages logged outside of an action get their own UUID:

```
$ .tox/py27/bin/python examples/rometrip_messages.py | .tox/py27/bin/eliot-tree | grep -v timestamp
81faaeaf-6f75-4eeb-8405-a43e1036accb
+-- honeymoon@1
    |-- family: [u'Mrs. Casaubon', u'Mr. Casaubon']

90fcf8cb-fcda-458a-ba43-db4fdb8b0255
+-- place:visited@1
    |-- person: Mrs. Casaubon
    |-- place: Rome, Italy

e4ff0526-ce1b-443c-bf0c-d7e296b78cba
+-- place:visited@1
    |-- person: Mrs. Casaubon
    |-- place: Vatican Museum

adb66e53-2a24-466b-aafe-b894a6ce4b29
+-- place:visited@1
    |-- person: Mrs. Casaubon
    |-- place: Statue #1

3f1f803c-4330-4c8a-a211-a9db797db4d0
+-- place:visited@1
    |-- person: Mrs. Casaubon
    |-- place: Statue #2

086dcedb-190b-42fd-a8fd-704ec36e22ba
+-- place:visited@1
    |-- person: Mr. Casaubon
    |-- place: Rome, Italy

7ab23f4e-096b-4bce-8eaa-13166c6924cd
+-- place:visited@1
    |-- person: Mr. Casaubon
    |-- place: Vatican Museum

b34cc40e-b578-444b-a0e1-b46bff95b2ef
+-- place:visited@1
    |-- person: Mr. Casaubon
    |-- place: Statue #1

d32d9d64-e951-43ef-809e-74e86c0640ad
+-- place:visited@1
    |-- person: Mr. Casaubon
    |-- place: Statue #2
```