### PR TITLE
Don't test task_uuid and task_level values

### DIFF
--- a/eliot/tests/test_output.py
+++ b/eliot/tests/test_output.py
@@ -556,16 +556,16 @@ class LoggerTests(TestCase):
 
         def remove(key):
             return [message.pop(key) for message in messages[1:]]
-        task_levels = remove(u"task_level")
-        task_uuids = remove(u"task_uuid")
+
+        # Make sure we have task_level & task_uuid in exception messages.
+        remove(u"task_level")
+        remove(u"task_uuid")
         timestamps = remove(u"timestamp")
 
         self.assertEqual(
-            (task_levels[1][-1] == task_levels[0][-1] + 1,
-             task_uuids[0] == task_uuids[1],
-             abs(timestamps[0] + timestamps[1] - 2 * time()) < 1,
+            (abs(timestamps[0] + timestamps[1] - 2 * time()) < 1,
              messages),
-            (True, True, True,
+            (True,
              [message,
               {"message_type": "eliot:destination_failure",
                "message": logger._safeUnicodeDictionary(message),

--- a/eliot/tests/test_output.py
+++ b/eliot/tests/test_output.py
@@ -11,6 +11,7 @@ from io import BytesIO, StringIO
 import json as pyjson
 from tempfile import mktemp
 from time import time
+from uuid import UUID
 
 from six import PY3, PY2
 
@@ -558,14 +559,16 @@ class LoggerTests(TestCase):
             return [message.pop(key) for message in messages[1:]]
 
         # Make sure we have task_level & task_uuid in exception messages.
-        remove(u"task_level")
-        remove(u"task_uuid")
+        task_levels = remove(u"task_level")
+        task_uuids = remove(u"task_uuid")
         timestamps = remove(u"timestamp")
 
         self.assertEqual(
             (abs(timestamps[0] + timestamps[1] - 2 * time()) < 1,
+             task_levels == [[1], [1]],
+             len([UUID(uuid) for uuid in task_uuids]) == 2,
              messages),
-            (True,
+            (True, True, True,
              [message,
               {"message_type": "eliot:destination_failure",
                "message": logger._safeUnicodeDictionary(message),


### PR DESCRIPTION
https://github.com/ClusterHQ/eliot/pull/195 and https://github.com/ClusterHQ/eliot/pull/198 together break the tests. #195 assumes that the two error messages share the same task, and #198 makes them completely independent.

Since sharing the same task is not actually part of the expected behaviour, the simplest solution is to relax the assertion.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/eliot/199)
<!-- Reviewable:end -->
