### PR TITLE
Define constants for field names and statuses

### DIFF
--- a/eliot/_message.py
+++ b/eliot/_message.py
@@ -12,6 +12,15 @@ from six import text_type as unicode
 from pyrsistent import PClass, field, pmap, thaw
 
 
+MESSAGE_TYPE_FIELD = 'message_type'
+TASK_UUID_FIELD = 'task_uuid'
+TASK_LEVEL_FIELD = 'task_level'
+TIMESTAMP_FIELD = 'timestamp'
+
+EXCEPTION_FIELD = 'exception'
+REASON_FIELD = 'reason'
+
+
 class Message(object):
     """
     A log message.
@@ -108,13 +117,13 @@ class Message(object):
             task_uuid = unicode(uuid4())
             task_level = [1]
         else:
-            task_uuid = action._identification['task_uuid']
+            task_uuid = action._identification[TASK_UUID_FIELD]
             task_level = thaw(action._nextTaskLevel().level)
         timestamp = self._timestamp()
         return self._contents.update({
-            'timestamp': timestamp,
-            'task_uuid': task_uuid,
-            'task_level': task_level,
+            TIMESTAMP_FIELD: timestamp,
+            TASK_UUID_FIELD: task_uuid,
+            TASK_LEVEL_FIELD: task_level,
         })
 
     def write(self, logger=None, action=None):
@@ -153,7 +162,7 @@ class WrittenMessage(PClass):
         """
         The Unix timestamp of when the message was logged.
         """
-        return self._logged_dict['timestamp']
+        return self._logged_dict[TIMESTAMP_FIELD]
 
 
     @property
@@ -161,7 +170,7 @@ class WrittenMessage(PClass):
         """
         The UUID of the task in which the message was logged.
         """
-        return self._logged_dict['task_uuid']
+        return self._logged_dict[TASK_UUID_FIELD]
 
 
     @property
@@ -169,7 +178,7 @@ class WrittenMessage(PClass):
         """
         The L{TaskLevel} of this message appears within the task.
         """
-        return TaskLevel(level=self._logged_dict['task_level'])
+        return TaskLevel(level=self._logged_dict[TASK_LEVEL_FIELD])
 
 
     @property
@@ -178,7 +187,7 @@ class WrittenMessage(PClass):
         A C{PMap}, the message contents without Eliot metadata.
         """
         return self._logged_dict.discard(
-            'timestamp').discard('task_uuid').discard('task_level')
+            TIMESTAMP_FIELD).discard(TASK_UUID_FIELD).discard(TASK_LEVEL_FIELD)
 
 
     @classmethod

--- a/eliot/_output.py
+++ b/eliot/_output.py
@@ -31,7 +31,12 @@ else:
 from zope.interface import Interface, implementer
 
 from ._traceback import writeTraceback, TRACEBACK_MESSAGE
-from ._message import Message
+from ._message import (
+    Message,
+    EXCEPTION_FIELD,
+    MESSAGE_TYPE_FIELD,
+    REASON_FIELD,
+)
 from ._util import saferepr, safeunicode
 
 
@@ -174,7 +179,7 @@ class Logger(object):
                 serializer.serialize(dictionary)
         except:
             writeTraceback(self)
-            msg = Message({"message_type": "eliot:serialization_failure",
+            msg = Message({MESSAGE_TYPE_FIELD: "eliot:serialization_failure",
                            "message": self._safeUnicodeDictionary(dictionary)})
             msg.write(self)
             return
@@ -189,9 +194,9 @@ class Logger(object):
                     # infinite recursion. So instead we have to manually
                     # construct a message.
                     msg = Message({
-                        "message_type": "eliot:destination_failure",
-                        "reason": safeunicode(exception),
-                        "exception":
+                        MESSAGE_TYPE_FIELD: "eliot:destination_failure",
+                        REASON_FIELD: safeunicode(exception),
+                        EXCEPTION_FIELD:
                         exc_type.__module__ + "." + exc_type.__name__,
                         "message": self._safeUnicodeDictionary(dictionary)})
                     self._destinations.send(dict(msg._freeze()))
@@ -252,7 +257,7 @@ class MemoryLogger(object):
         result = []
         remaining = []
         for message in self.tracebackMessages:
-            if isinstance(message["reason"], exceptionType):
+            if isinstance(message[REASON_FIELD], exceptionType):
                 result.append(message)
             else:
                 remaining.append(message)

--- a/eliot/_traceback.py
+++ b/eliot/_traceback.py
@@ -11,15 +11,17 @@ from warnings import warn
 
 from six import exec_
 
+from ._message import EXCEPTION_FIELD, REASON_FIELD
 from ._util import safeunicode
 from ._validation import MessageType, Field
 
 
 TRACEBACK_MESSAGE = MessageType(
     "eliot:traceback",
-    [Field("reason", safeunicode, "The exception's value."),
+    [Field(REASON_FIELD, safeunicode, "The exception's value."),
      Field("traceback", safeunicode, "The traceback."),
-     Field("exception", lambda typ: "%s.%s" % (typ.__module__, typ.__name__),
+     Field(EXCEPTION_FIELD,
+           lambda typ: "%s.%s" % (typ.__module__, typ.__name__),
            "The exception type's FQPN.")],
     "An unexpected exception indicating a bug.")
 


### PR DESCRIPTION
Rather than using anything nice like Python 3.4's `enum` or `twisted.python.constants`, I've just defined a bunch of variables with similar-looking names. I think this makes the code more readable and makes some of the structure of eliot more explicit.

I haven't updated usage in tests, but can if you'd like.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/eliot/200)
<!-- Reviewable:end -->
