### PR TITLE
Parse messages into a tree

### DIFF
--- a/eliot/_action.py
+++ b/eliot/_action.py
@@ -507,6 +507,7 @@ class InvalidStartMessage(Exception):
         return cls(message, 'first message must have task level ending in 1')
 
 
+#@implementer(IWrittenAction)
 class WrittenAction(PClass):
     """
     An Action that has been logged.
@@ -524,8 +525,8 @@ class WrittenAction(PClass):
 
     start_message = field(type=WrittenMessage, mandatory=True)
     end_message = field(type=optional(WrittenMessage), mandatory=True)
-    # XXX: Actually a map to either WrittenMessage or WrittenAction, but
-    # pyrsistent doesn't support recursive data types:
+    # XXX: Actually a map to either WrittenMessage, WrittenAction or
+    # MissingAction, but pyrsistent doesn't support recursive data types:
     # https://github.com/tobgu/pyrsistent/issues/48
     _children = pmap_field(TaskLevel, object)
 

--- a/eliot/_action.py
+++ b/eliot/_action.py
@@ -8,7 +8,7 @@ top-level actions.
 from __future__ import unicode_literals, absolute_import
 
 import threading
-from uuid import uuid4
+from uuid import uuid4, UUID
 from itertools import count
 from contextlib import contextmanager
 from warnings import warn
@@ -507,7 +507,6 @@ class InvalidStartMessage(Exception):
         return cls(message, 'first message must have task level ending in 1')
 
 
-#@implementer(IWrittenAction)
 class WrittenAction(PClass):
     """
     An Action that has been logged.
@@ -516,29 +515,37 @@ class WrittenAction(PClass):
     action actually is, and a means of constructing actions that are known to
     be valid.
 
-    @ivar WrittenMessage start_message: The message that started this action.
+    @ivar WrittenMessage start_message: The message that started this
+        action, or C{None} if it is not yet set on the action.
     @ivar WrittenMessage end_message: The message that ends this action. Can be
         C{None} if the action is unfinished.
+    @ivar TaskLevel task_level: The action's task level, e.g. if start
+        message has level C{[2, 3, 1]} it will be
+        C{TaskLevel(level=[2, 3])}.
+    @ivar UUID task_uuid: The UUID of the task to which this action belongs.
     @ivar _children: A L{pmap} from L{TaskLevel} to the L{WrittenAction} and
         L{WrittenMessage} objects that make up this action.
     """
 
-    start_message = field(type=WrittenMessage, mandatory=True)
-    end_message = field(type=optional(WrittenMessage), mandatory=True)
-    # XXX: Actually a map to either WrittenMessage, WrittenAction or
-    # MissingAction, but pyrsistent doesn't support recursive data types:
-    # https://github.com/tobgu/pyrsistent/issues/48
+    start_message = field(type=optional(WrittenMessage), mandatory=True,
+                          initial=None)
+    end_message = field(type=optional(WrittenMessage), mandatory=True,
+                        initial=None)
+    task_level = field(type=TaskLevel, mandatory=True)
+    task_uuid = field(type=unicode, mandatory=True, factory=unicode)
+    # Pyrsistent doesn't support pmap_field with recursive types.
     _children = pmap_field(TaskLevel, object)
 
     @classmethod
-    def from_messages(cls, start_message, children=pvector(), end_message=None):
+    def from_messages(cls, start_message=None, children=pvector(),
+                      end_message=None):
         """
         Create a C{WrittenAction} from C{WrittenMessage}s and other
         C{WrittenAction}s.
 
         @param WrittenMessage start_message: A message that has
             C{ACTION_STATUS_FIELD}, C{ACTION_TYPE_FIELD}, and a C{task_level}
-            that ends in C{1}.
+            that ends in C{1}, or C{None} if unavailable.
         @param children: An iterable of C{WrittenMessage} and C{WrittenAction}
         @param WrittenMessage end_message: A message that has the same
             C{action_type} as this action.
@@ -559,19 +566,21 @@ class WrittenAction(PClass):
 
         @return: A new C{WrittenAction}.
         """
-        if start_message.contents.get(ACTION_STATUS_FIELD, None) != STARTED_STATUS:
-            raise InvalidStartMessage.wrong_status(start_message)
-        if start_message.task_level.level[-1] != 1:
-            raise InvalidStartMessage.wrong_task_level(start_message)
+        actual_message = [message for message in
+                          [start_message, end_message] + list(children)
+                          if message][0]
         action = cls(
-            start_message=start_message,
-            _children=pmap(),
-            end_message=None,
+            task_level=actual_message.task_level.parent(),
+            task_uuid=actual_message.task_uuid,
         )
+        if start_message:
+            action = action._start(start_message)
         for child in children:
+            if action._children.get(child.task_level, child) != child:
+                raise DuplicateChild(action, child)
             action = action._add_child(child)
         if end_message:
-            return action._end(end_message)
+            action = action._end(end_message)
         return action
 
     @property
@@ -579,36 +588,32 @@ class WrittenAction(PClass):
         """
         The type of this action, e.g. C{"yourapp:subsystem:dosomething"}.
         """
-        return self.start_message.contents[ACTION_TYPE_FIELD]
+        if self.start_message:
+            return self.start_message.contents[ACTION_TYPE_FIELD]
+        elif self.end_message:
+            return self.end_message.contents[ACTION_TYPE_FIELD]
+        else:
+            return None
 
     @property
     def status(self):
         """
-        One of C{STARTED_STATUS}, C{SUCCEEDED_STATUS}, or C{FAILED_STATUS}.
+        One of C{STARTED_STATUS}, C{SUCCEEDED_STATUS}, C{FAILED_STATUS} or
+        C{None}.
         """
         message = self.end_message if self.end_message else self.start_message
-        return message.contents[ACTION_STATUS_FIELD]
-
-    @property
-    def task_uuid(self):
-        """
-        The UUID of the task to which this action belongs.
-        """
-        return self.start_message.task_uuid
-
-    @property
-    def task_level(self):
-        """
-        The level of the task in which the action occurs.
-        """
-        return self.start_message.task_level.parent()
+        if message:
+            return message.contents[ACTION_STATUS_FIELD]
+        else:
+            return None
 
     @property
     def start_time(self):
         """
         The Unix timestamp of when the action started.
         """
-        return self.start_message.timestamp
+        if self.start_message:
+            return self.start_message.timestamp
 
     @property
     def end_time(self):
@@ -679,9 +684,26 @@ class WrittenAction(PClass):
         """
         self._validate_message(message)
         level = message.task_level
-        if self._children.get(level, message) != message:
-            raise DuplicateChild(self, message)
         return self.transform(('_children', level), message)
+
+    def _start(self, start_message):
+        """
+        Start this action given its start message.
+
+        @param WrittenMessage start_message: A start message that has the
+            same level as this action.
+
+        @raise InvalidStartMessage: If C{start_message} does not have a
+            C{ACTION_STATUS_FIELD} of C{STARTED_STATUS}, or if it has a
+            C{task_level} indicating that it is not the first message of an
+            action.
+        """
+        if start_message.contents.get(
+                ACTION_STATUS_FIELD, None) != STARTED_STATUS:
+            raise InvalidStartMessage.wrong_status(start_message)
+        if start_message.task_level.level[-1] != 1:
+            raise InvalidStartMessage.wrong_task_level(start_message)
+        return self.set(start_message=start_message)
 
     def _end(self, end_message):
         """
@@ -689,25 +711,23 @@ class WrittenAction(PClass):
 
         Assumes that the action has not already been ended.
 
-        @param WrittenMessage end_message: A message that has the same
-            C{action_type} as this action.
+        @param WrittenMessage end_message: An end message that has the
+            same level as this action.
 
         @raise WrongTask: If C{end_message} has a C{task_uuid} that differs
             from the action's C{task_uuid}.
         @raise WrongTaskLevel: If C{end_message} has a C{task_level} that means
             it's not a direct child.
-        @raise WrongActionType: If C{end_message} has an C{action_type} that
-            differs from the current action.
         @raise InvalidStatus: If C{end_message} doesn't have an
             C{action_status}, or has one that is not C{SUCCEEDED_STATUS} or
             C{FAILED_STATUS}.
 
         @return: A new, completed C{WrittenAction}.
         """
-        self._validate_message(end_message)
         action_type = end_message.contents.get(ACTION_TYPE_FIELD, None)
-        if action_type != self.action_type:
+        if self.action_type not in (None, action_type):
             raise WrongActionType(self, end_message)
+        self._validate_message(end_message)
         status = end_message.contents.get(ACTION_STATUS_FIELD, None)
         if status not in (FAILED_STATUS, SUCCEEDED_STATUS):
             raise InvalidStatus(self, end_message)

--- a/eliot/_action.py
+++ b/eliot/_action.py
@@ -515,10 +515,12 @@ class WrittenAction(PClass):
     action actually is, and a means of constructing actions that are known to
     be valid.
 
-    @ivar WrittenMessage start_message: The message that started this
-        action, or C{None} if it is not yet set on the action.
-    @ivar WrittenMessage end_message: The message that ends this action. Can be
-        C{None} if the action is unfinished.
+    @ivar WrittenMessage start_message: A start message whose task UUID and
+        level match this action, or C{None} if it is not yet set on the
+        action.
+    @ivar WrittenMessage end_message: An end message hose task UUID and
+        level match this action. Can be C{None} if the action is
+        unfinished.
     @ivar TaskLevel task_level: The action's task level, e.g. if start
         message has level C{[2, 3, 1]} it will be
         C{TaskLevel(level=[2, 3])}.
@@ -610,7 +612,8 @@ class WrittenAction(PClass):
     @property
     def start_time(self):
         """
-        The Unix timestamp of when the action started.
+        The Unix timestamp of when the action started, or C{None} if there has
+        been no start message added so far.
         """
         if self.start_message:
             return self.start_message.timestamp

--- a/eliot/_action.py
+++ b/eliot/_action.py
@@ -8,13 +8,13 @@ top-level actions.
 from __future__ import unicode_literals, absolute_import
 
 import threading
-from uuid import uuid4, UUID
+from uuid import uuid4
 from itertools import count
 from contextlib import contextmanager
 from warnings import warn
 
 from pyrsistent import (
-    field, PClass, optional, pmap_field, pvector_field, pmap, pvector,
+    field, PClass, optional, pmap_field, pvector_field, pvector,
 )
 
 from six import text_type as unicode

--- a/eliot/_message.py
+++ b/eliot/_message.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 
 from six import text_type as unicode
 
-from pyrsistent import PClass, field, pmap, thaw
+from pyrsistent import PClass, thaw, pmap_field, pmap
 
 
 MESSAGE_TYPE_FIELD = 'message_type'
@@ -155,7 +155,7 @@ class WrittenMessage(PClass):
     @ivar _logged_dict: The originally logged dictionary.
     """
 
-    _logged_dict = field()
+    _logged_dict = pmap_field(object, object)
 
     @property
     def timestamp(self):

--- a/eliot/_parse.py
+++ b/eliot/_parse.py
@@ -88,18 +88,18 @@ class Task(PClass):
         written_message = WrittenMessage.from_dict(message_dict)
         if is_action:
             action_level = written_message.task_level.parent()
-            current_action = self._nodes.get(action_level)
-            if current_action is None:
-                current_action = MissingAction(_task_level=action_level)
+            action = self._nodes.get(action_level)
+            if action is None:
+                action = MissingAction(_task_level=action_level)
             if message_dict[ACTION_STATUS_FIELD] == STARTED_STATUS:
-                new_node = current_action.to_written_action(written_message)
+                action = action.to_written_action(written_message)
             else:
-                new_node = current_action.set(end_message=written_message)
-            return self._insert_action(new_node)
+                action = action.set(end_message=written_message)
+            return self._insert_action(action)
         else:
-            new_node = written_message
             # Special case where there is no action:
-            if new_node.task_level.level == [1]:
-                return self.transform(["_nodes", self._root_level], new_node)
+            if written_message.task_level.level == [1]:
+                return self.transform(
+                    ["_nodes", self._root_level], written_message)
             else:
-                return self._ensure_node_parents(new_node)
+                return self._ensure_node_parents(written_message)

--- a/eliot/_parse.py
+++ b/eliot/_parse.py
@@ -5,6 +5,8 @@ Parse a stream of serialized messages into a forest of
 # XXX maybe move Written* here.
 """
 
+from __future__ import unicode_literals
+
 from pyrsistent import PClass, field, pmap_field, optional, pvector
 
 from ._message import WrittenMessage
@@ -21,13 +23,11 @@ class MissingAction(PClass):
                         initial=None)
     _children = pmap_field(TaskLevel, object)
 
+    action_type = "*unknown*"
+
     @property
     def task_level(self):
         return self._task_level
-
-    @property
-    def action_type(self):
-        return u"*unknown*"
 
     @property
     def children(self):

--- a/eliot/_parse.py
+++ b/eliot/_parse.py
@@ -1,5 +1,39 @@
 """
 Parse a stream of serialized messages into a forest of
 ``WrittenAction`` and ``WrittenMessage`` objects.
+
+# XXX maybe move Written* here.
 """
 
+from pyrsistent import PClass, field, pmap_field, optional
+
+from ._message import WrittenMessage
+from ._action import TaskLevel, WrittenAction
+
+
+#@implementer(IWrittenAction)
+class MissingAction(PClass):
+    end_message = field(type=optional(WrittenMessage), mandatory=True)
+    _children = pmap_field(TaskLevel, object)
+
+
+class Task(PClass):
+    """
+    A tree of actions with the same task UUID.
+    """
+    _root = field(type=(MissingAction, WrittenAction, WrittenMessage),
+                  mandatory=True)
+
+    @classmethod
+    def from_messages(cls, messages):
+        task = cls.create(messages[0])
+        for message in messages[1:]:
+            task = task.add(message)
+        return task
+
+    @classmethod
+    def create(cls, first_message):
+        pass
+
+    def add(self, message):
+        pass

--- a/eliot/_parse.py
+++ b/eliot/_parse.py
@@ -7,50 +7,20 @@ Parse a stream of serialized messages into a forest of
 
 from __future__ import unicode_literals
 
-from pyrsistent import PClass, field, pmap_field, optional, pvector
+from pyrsistent import PClass, pmap_field
 
-from ._message import WrittenMessage
+from ._message import WrittenMessage, TASK_UUID_FIELD
 from ._action import (
     TaskLevel, WrittenAction, ACTION_STATUS_FIELD, STARTED_STATUS,
     ACTION_TYPE_FIELD,
 )
 
 
-#@implementer(IWrittenAction)
-class MissingAction(PClass):
-    _task_level = field(type=TaskLevel, mandatory=True)
-    end_message = field(type=optional(WrittenMessage), mandatory=True,
-                        initial=None)
-    _children = pmap_field(TaskLevel, object)
-
-    action_type = "*unknown*"
-
-    @property
-    def task_level(self):
-        return self._task_level
-
-    @property
-    def children(self):
-        """
-        The list of child messages and actions sorted by task level, excluding the
-        start and end messages.
-        """
-        return pvector(sorted(self._children.values(), key=lambda m: m.task_level))
-
-    def to_written_action(self, start_message):
-        return WrittenAction(start_message=start_message,
-                             end_message=self.end_message,
-                             _children=self._children)
-
-
-_NODES = (MissingAction, WrittenAction, WrittenMessage)
-
-
 class Task(PClass):
     """
     A tree of actions with the same task UUID.
     """
-    _nodes = pmap_field(TaskLevel, object) # XXX _NODES
+    _nodes = pmap_field(TaskLevel, (WrittenAction, WrittenMessage))
 
     _root_level = TaskLevel(level=[])
 
@@ -74,8 +44,9 @@ class Task(PClass):
 
         parent = self._nodes.get(task_level.parent())
         if parent is None:
-            parent = MissingAction(_task_level=task_level.parent())
-        parent = parent.transform(["_children", task_level], child)
+            parent = WrittenAction(task_level=task_level.parent(),
+                                   task_uuid=child.task_uuid)
+        parent = parent._add_child(child)
         return self._insert_action(parent)
 
     def add(self, message_dict):
@@ -85,13 +56,14 @@ class Task(PClass):
             action_level = written_message.task_level.parent()
             action = self._nodes.get(action_level)
             if action is None:
-                action = MissingAction(_task_level=action_level)
+                action = WrittenAction(task_level=action_level,
+                                       task_uuid=message_dict[TASK_UUID_FIELD])
             if message_dict[ACTION_STATUS_FIELD] == STARTED_STATUS:
                 # Either newly created MissingAction, or one created by
                 # previously added descendant of the action.
-                action = action.to_written_action(written_message)
+                action = action._start(written_message)
             else:
-                action = action.set(end_message=written_message)
+                action = action._end(written_message)
             return self._insert_action(action)
         else:
             # Special case where there is no action:

--- a/eliot/_parse.py
+++ b/eliot/_parse.py
@@ -54,11 +54,6 @@ class Task(PClass):
 
     _root_level = TaskLevel(level=[])
 
-    @classmethod
-    def create(cls, first_message):
-        task = Task()
-        return task.add(first_message)
-
     def root(self):
         return self._nodes[self._root_level]
 

--- a/eliot/_parse.py
+++ b/eliot/_parse.py
@@ -10,6 +10,7 @@ from pyrsistent import PClass, field, pmap_field, optional, pvector
 from ._message import WrittenMessage
 from ._action import (
     TaskLevel, WrittenAction, ACTION_STATUS_FIELD, STARTED_STATUS,
+    ACTION_TYPE_FIELD,
 )
 
 
@@ -75,7 +76,7 @@ class Task(PClass):
 
     def add(self, message_dict):
         task = self
-        is_action = message_dict.get("action_type") is not None
+        is_action = message_dict.get(ACTION_TYPE_FIELD) is not None
         written_message = WrittenMessage.from_dict(message_dict)
         action_level = written_message.task_level
         if is_action:

--- a/eliot/_parse.py
+++ b/eliot/_parse.py
@@ -1,8 +1,6 @@
 """
 Parse a stream of serialized messages into a forest of
 ``WrittenAction`` and ``WrittenMessage`` objects.
-
-# XXX maybe move Written* here.
 """
 
 from __future__ import unicode_literals
@@ -25,18 +23,35 @@ class Task(PClass):
     _root_level = TaskLevel(level=[])
 
     def root(self):
+        """
+        @return: The root L{WrittenAction}.
+        """
         return self._nodes[self._root_level]
 
     def _insert_action(self, node):
+        """
+        Add a L{WrittenAction} to the tree.
+
+        Parent actions will be created as necessary.
+
+        @param child: A L{WrittenAction} to add to the tree.
+
+        @return: Updated L{Task}.
+        """
         task = self.transform(["_nodes", node.task_level], node)
         return task._ensure_node_parents(node)
 
     def _ensure_node_parents(self, child):
         """
-        Ensure the node (WrittenAction/WrittenMessage/MissingAction) is
-        referenced by parent nodes.
+        Ensure the node (WrittenAction/WrittenMessage) is referenced by parent
+        nodes.
 
-        MissingAction will be created as necessary.
+        Parent actions will be created as necessary.
+
+        @param child: A L{WrittenMessage} or L{WrittenAction} which is
+            being added to the tree.
+
+        @return: Updated L{Task}.
         """
         task_level = child.task_level
         if task_level.parent() is None:
@@ -50,6 +65,14 @@ class Task(PClass):
         return self._insert_action(parent)
 
     def add(self, message_dict):
+        """
+        Update the L{Task} with a dictionary containing a serialized Eliot
+        message.
+
+        @param message_dict: Dictionary whose task UUID matches this one.
+
+        @return: Updated L{Task}.
+        """
         is_action = message_dict.get(ACTION_TYPE_FIELD) is not None
         written_message = WrittenMessage.from_dict(message_dict)
         if is_action:

--- a/eliot/_parse.py
+++ b/eliot/_parse.py
@@ -1,0 +1,5 @@
+"""
+Parse a stream of serialized messages into a forest of
+``WrittenAction`` and ``WrittenMessage`` objects.
+"""
+

--- a/eliot/_parse.py
+++ b/eliot/_parse.py
@@ -25,13 +25,6 @@ class Task(PClass):
                   mandatory=True)
 
     @classmethod
-    def from_messages(cls, messages):
-        task = cls.create(messages[0])
-        for message in messages[1:]:
-            task = task.add(message)
-        return task
-
-    @classmethod
     def create(cls, first_message):
         pass
 

--- a/eliot/_parse.py
+++ b/eliot/_parse.py
@@ -92,6 +92,8 @@ class Task(PClass):
             if action is None:
                 action = MissingAction(_task_level=action_level)
             if message_dict[ACTION_STATUS_FIELD] == STARTED_STATUS:
+                # Either newly created MissingAction, or one created by
+                # previously added descendant of the action.
                 action = action.to_written_action(written_message)
             else:
                 action = action.set(end_message=written_message)

--- a/eliot/_parse.py
+++ b/eliot/_parse.py
@@ -5,28 +5,85 @@ Parse a stream of serialized messages into a forest of
 # XXX maybe move Written* here.
 """
 
-from pyrsistent import PClass, field, pmap_field, optional
+from pyrsistent import PClass, field, pmap_field, optional, pvector
 
 from ._message import WrittenMessage
-from ._action import TaskLevel, WrittenAction
+from ._action import (
+    TaskLevel, WrittenAction, ACTION_STATUS_FIELD, STARTED_STATUS,
+)
 
 
 #@implementer(IWrittenAction)
 class MissingAction(PClass):
-    end_message = field(type=optional(WrittenMessage), mandatory=True)
+    _task_level = field(type=TaskLevel, mandatory=True)
+    end_message = field(type=optional(WrittenMessage), mandatory=True,
+                        initial=None)
     _children = pmap_field(TaskLevel, object)
+
+    def task_level(self):
+        return self._task_level
+
+    def action_type(self):
+        return u"*unknown*"
+
+    @property
+    def children(self):
+        """
+        The list of child messages and actions sorted by task level, excluding the
+        start and end messages.
+        """
+        return pvector(sorted(self._children.values(), key=lambda m: m.task_level))
+
+
+_NODES = (MissingAction, WrittenAction, WrittenMessage)
 
 
 class Task(PClass):
     """
     A tree of actions with the same task UUID.
     """
-    _root = field(type=(MissingAction, WrittenAction, WrittenMessage),
-                  mandatory=True)
+    _nodes = pmap_field(TaskLevel, object) # XXX _NODES
 
     @classmethod
     def create(cls, first_message):
-        pass
+        task = Task()
+        return task.add(first_message)
 
-    def add(self, message):
-        pass
+    def root(self):
+        return self._nodes[TaskLevel(level=[])]
+
+    def _add_new_node(self, new_node, initial_task_level):
+        task = self
+        child = new_node
+        task_level = initial_task_level
+        while task_level.parent() is not None:
+            parent = self._nodes.get(task_level.parent())
+            if parent is None:
+                parent = MissingAction(_task_level=task_level.parent())
+            parent = parent.transform(["_children", task_level], child)
+            task = task.transform(["_nodes", parent.task_level()], parent)
+            child = parent
+            task_level = parent.task_level()
+        return task
+
+    def add(self, message_dict):
+        task = self
+        is_action = message_dict.get("action_type") is not None
+        written_message = WrittenMessage.from_dict(message_dict)
+        action_level = written_message.task_level
+        if is_action:
+            current_action = self._nodes.get(action_level)
+            if message_dict[ACTION_STATUS_FIELD] == STARTED_STATUS:
+                if current_action is None:
+                    new_node = WrittenAction.from_messages(written_message)
+                else:
+                    new_node = current_action.to_written_action(
+                        written_message)
+            else:
+                new_node = current_action.set(end_message=written_message)
+            task_level = new_node.task_level()
+        else:
+            new_node = written_message
+            task_level = written_message.task_level
+        task = task._add_new_node(new_node, task_level)
+        return task

--- a/eliot/_parse.py
+++ b/eliot/_parse.py
@@ -68,9 +68,9 @@ class Task(PClass):
             if parent is None:
                 parent = MissingAction(_task_level=task_level.parent())
             parent = parent.transform(["_children", task_level], child)
-            task = task.transform(["_nodes", parent.task_level()], parent)
+            task = task.transform(["_nodes", parent.task_level], parent)
             child = parent
-            task_level = parent.task_level()
+            task_level = parent.task_level
         return task
 
     def add(self, message_dict):
@@ -79,7 +79,7 @@ class Task(PClass):
         written_message = WrittenMessage.from_dict(message_dict)
         action_level = written_message.task_level
         if is_action:
-            current_action = self._nodes.get(action_level)
+            current_action = self._nodes.get(action_level.parent())
             if current_action is None:
                 current_action = MissingAction(
                     _task_level=action_level.parent())
@@ -99,6 +99,5 @@ class Task(PClass):
             if new_node.task_level.level == [1]:
                 return task.transform(["_nodes", TaskLevel(level=[])],
                                       new_node)
-        print new_node
         task = task._add_new_node(new_node)
         return task

--- a/eliot/tests/strategies.py
+++ b/eliot/tests/strategies.py
@@ -44,7 +44,7 @@ task_levels = task_level_lists.map(lambda level: TaskLevel(level=level))
 
 
 # Text generation is slow, and most of the things are short labels.
-labels = text(average_size=5, min_size=1)
+labels = text(average_size=3, min_size=1, alphabet="CGAT")
 
 timestamps = floats(min_value=0)
 

--- a/eliot/tests/strategies.py
+++ b/eliot/tests/strategies.py
@@ -62,7 +62,7 @@ message_core_dicts = fixed_dictionaries(
 # Text generation is slow. We can make it faster by not generating so
 # much. These are reasonable values.
 message_data_dicts = dictionaries(
-    keys=labels, values=text(average_size=10),
+    keys=labels, values=labels,
     # People don't normally put much more than twenty fields in their
     # messages, surely?
     average_size=10,
@@ -115,8 +115,8 @@ _end_action_fields = one_of(
         ACTION_STATUS_FIELD: just(FAILED_STATUS),
         # Text generation is slow. We can make it faster by not generating so
         # much. Thqese are reasonable values.
-        EXCEPTION_FIELD: text(average_size=20),
-        REASON_FIELD: text(average_size=20),
+        EXCEPTION_FIELD: labels,
+        REASON_FIELD: labels,
     }),
 )
 

--- a/eliot/tests/strategies.py
+++ b/eliot/tests/strategies.py
@@ -43,7 +43,10 @@ task_level_lists = lists(task_level_indexes, min_size=1, average_size=5)
 task_levels = task_level_lists.map(lambda level: TaskLevel(level=level))
 
 
-# Text generation is slow, and most of the things are short labels.
+# Text generation is slow, and most of the things are short labels. We set
+# a restricted alphabet so they're easier to read, and in general large
+# amount of randomness in label generation doesn't enhance our testing in
+# any way, since we don't parse type names or user field values.
 labels = text(average_size=3, min_size=1, alphabet="CGAT")
 
 timestamps = floats(min_value=0)

--- a/eliot/tests/test_parse.py
+++ b/eliot/tests/test_parse.py
@@ -1,0 +1,16 @@
+"""
+Tests for L{eliot._parse}.
+"""
+
+'''
+Basic idea for testing parsing:
+
+Create a tree of Eliot actions and messages (using Hypothesis stateful
+testing? Normal hypothesis tests?). Feed resulting messages into parser in
+random order. At the end we should get expected result.
+
+The key thought here is that if any random order is correct then the
+intermediate states must be correct too.
+
+Additional coverage is likely needed that is specific to missing actions.
+'''

--- a/eliot/tests/test_parse.py
+++ b/eliot/tests/test_parse.py
@@ -53,7 +53,7 @@ class ActionStructure(PClass):
 
 TYPES = strategies.text(min_size=1, average_size=3, alphabet=u"CGAT")
 ACTION_STRUCTURES = strategies.recursive(
-    TYPES, strategies.lists, max_leaves=5).map(ActionStructure.from_tree)
+    TYPES, strategies.lists, max_leaves=10).map(ActionStructure.from_tree)
 
 
 class TaskTests(TestCase):

--- a/eliot/tests/test_parse.py
+++ b/eliot/tests/test_parse.py
@@ -15,16 +15,16 @@ from .._parse import Task
 from .._message import WrittenMessage
 
 
-class StubAction(PClass):
+class ActionStructure(PClass):
     type = field(type=unicode, mandatory=True)
     children = pvector_field(("StubAction", unicode), mandatory=True)
 
     @classmethod
     def _from_tree(cls, tree_or_message):
         if isinstance(tree_or_message, list):
-            return StubAction(
+            return cls(
                 type=TYPES.example(),
-                children=[StubAction._from_tree(o) for o in tree_or_message])
+                children=[cls._from_tree(o) for o in tree_or_message])
         else:
             return tree_or_message
 
@@ -33,26 +33,26 @@ class StubAction(PClass):
         if isinstance(written, WrittenMessage):
             return written.message_type
         else:  # WrittenAction
-            return StubAction(
+            return cls(
                 type=written.action_type,
-                children=[StubAction.from_written(o) for o in written.children]
+                children=[cls.from_written(o) for o in written.children]
                 + [written.end_message])
 
     @classmethod
-    def to_eliot(cls, stub_or_message):
-        if isinstance(stub_or_message, cls):
-            action = stub_or_message
+    def to_eliot(cls, structure_or_message):
+        if isinstance(structure_or_message, cls):
+            action = structure_or_message
             with start_action(action_type=action.type):
                 for child in action.children:
                     cls.to_eliot(child)
         else:
-            Message.log(message_type=stub_or_message)
+            Message.log(message_type=structure_or_message)
 
 
 TYPES = strategies.text(min_size=1, average_size=3, alphabet=u"CGAT")
-TASKS = strategies.recursive(
+ACTION_STRUCTURES = strategies.recursive(
     strategies.text(min_size=1, average_size=3, alphabet=u"CGAT"),
-    strategies.lists, max_leaves=5).map(StubAction.from_tree)
+    strategies.lists, max_leaves=5).map(ActionStructure.from_tree)
 
 
 class TaskTests(TestCase):
@@ -67,16 +67,22 @@ class TaskTests(TestCase):
     Additional coverage is then needed that is specific to the intermediate
     states, i.e. missing messages.
     """
-    @strategy(task_structure=TASKS)
-    @example(task_structure=u"standalone_message")
-    @example(task_structure=[])
+    @strategy(action_structure=ACTION_STRUCTURES)
+    @example(action_structure=u"standalone_message")
     @capture_logging(None)
-    def test_parse_from_random_order(self, logger, task_structure):
-        StubAction.to_eliot(task_structure)
+    def test_parse_from_random_order(self, logger, action_structure):
+        # Create Eliot messages for given tree of actions and messages:
+        ActionStructure.to_eliot(action_structure)
         messages = logger.messages
+
+        # Parse resulting message dicts in random order:
         order = range(len(messages))
         shuffle(order)
-        task = Task.from_messages([messages[i] for i in order])
-        parsed_structure = StubAction.from_written(task.root())
-        self.assertEqual(parsed_structure, task_structure,
+        task = Task.create(messages[order[0]])
+        for index in order[1:]:
+            task = task.add(messages[index])
+
+        # Assert parsed structure matches input structure:
+        parsed_structure = ActionStructure.from_written(task.root())
+        self.assertEqual(parsed_structure, action_structure,
                          "Order: {}".format(order))

--- a/eliot/tests/test_parse.py
+++ b/eliot/tests/test_parse.py
@@ -6,6 +6,8 @@ from __future__ import unicode_literals
 
 from unittest import TestCase
 
+from six import text_type as unicode
+
 from hypothesis import strategies as st, given, assume
 
 from pyrsistent import PClass, field, pvector_field

--- a/eliot/tests/test_parse.py
+++ b/eliot/tests/test_parse.py
@@ -12,58 +12,68 @@ from .. import start_action, Message
 from ..testing import MemoryLogger
 from .._parse import Task
 from .._message import WrittenMessage, MESSAGE_TYPE_FIELD
+from .._action import FAILED_STATUS, ACTION_TYPE_FIELD
 
 
 class ActionStructure(PClass):
-    type = field(type=unicode, mandatory=True)
+    type = field(type=unicode)
     children = pvector_field(object)  # XXX ("StubAction", unicode))
-
-    @classmethod
-    def from_tree(cls, tree_or_message):
-        if isinstance(tree_or_message, list):
-            return cls(
-                type=TYPES.example(),
-                children=[cls.from_tree(o) for o in tree_or_message])
-        else:
-            return tree_or_message
+    failed = field(type=bool)
 
     @classmethod
     def from_written(cls, written):
         if isinstance(written, WrittenMessage):
             return written.as_dict()[MESSAGE_TYPE_FIELD]
         else:  # WrittenAction
-            if not written.end_message:# or written.end_message.as_dict()[MESSAGE_TYPE_FIELD]:
-                raise AssertionError("XXX ugh this is a bad check")
+            if not written.end_message or (
+                    written.end_message.as_dict()[ACTION_TYPE_FIELD] !=
+                    written.action_type):
+                raise AssertionError("Wrong type on end message.")
             return cls(
                 type=written.action_type,
+                failed=(written.status == FAILED_STATUS),
                 children=[cls.from_written(o) for o in written.children])
 
     @classmethod
     def to_eliot(cls, structure_or_message, logger):
         if isinstance(structure_or_message, cls):
             action = structure_or_message
-            with start_action(logger, action_type=action.type):
-                for child in action.children:
-                    cls.to_eliot(child, logger)
+            try:
+                with start_action(logger, action_type=action.type):
+                    for child in action.children:
+                        cls.to_eliot(child, logger)
+                    if structure_or_message.failed:
+                        raise RuntimeError("Make the eliot action fail.")
+            except RuntimeError:
+                pass
         else:
             Message.new(message_type=structure_or_message).write(logger)
         return logger.messages
 
 
-def _build_structure_strategy():
-    strategy = st.recursive(TYPES, st.lists, max_leaves=10)
-    strategy = strategy.map(ActionStructure.from_tree)
-
-    def structure_and_messages(structure):
-        messages = ActionStructure.to_eliot(structure, MemoryLogger())
-        return st.permutations(messages).map(
-            lambda permuted: (structure, permuted))
-    strategy = strategy.flatmap(structure_and_messages)
-    return strategy
-
-
 TYPES = st.text(min_size=1, average_size=3, alphabet=u"CGAT")
-ACTION_STRUCTURES = _build_structure_strategy()
+
+
+@st.composite
+def action_structures(draw):
+    tree = draw(st.recursive(TYPES, st.lists, max_leaves=10))
+
+    def to_structure(tree_or_message):
+        if isinstance(tree_or_message, list):
+            return ActionStructure(
+                type=draw(TYPES),
+                failed=draw(st.booleans()),
+                children=[to_structure(o) for o in tree_or_message])
+        else:
+            return tree_or_message
+    return to_structure(tree)
+
+
+def _structure_and_messages(structure):
+    messages = ActionStructure.to_eliot(structure, MemoryLogger())
+    return st.permutations(messages).map(
+        lambda permuted: (structure, permuted))
+STRUCTURES_WITH_MESSAGES = action_structures().flatmap(_structure_and_messages)
 
 
 class TaskTests(TestCase):
@@ -78,7 +88,7 @@ class TaskTests(TestCase):
     Additional coverage is then needed that is specific to the intermediate
     states, i.e. missing messages.
     """
-    @given(structure_and_messages=ACTION_STRUCTURES)
+    @given(structure_and_messages=STRUCTURES_WITH_MESSAGES)
     def test_parse_from_random_order(self, structure_and_messages):
         action_structure, messages = structure_and_messages
 

--- a/eliot/tests/test_parse.py
+++ b/eliot/tests/test_parse.py
@@ -40,13 +40,12 @@ class ActionStructure(PClass):
                 children=[cls.from_written(o) for o in written.children])
 
     @classmethod
-    def to_eliot(cls, structure_or_message):
-        logger = MemoryLogger()
+    def to_eliot(cls, structure_or_message, logger):
         if isinstance(structure_or_message, cls):
             action = structure_or_message
             with start_action(logger, action_type=action.type):
                 for child in action.children:
-                    cls.to_eliot(child)
+                    cls.to_eliot(child, logger)
         else:
             Message.new(message_type=structure_or_message).write(logger)
         return logger.messages
@@ -73,7 +72,8 @@ class TaskTests(TestCase):
     @example(action_structure=u"standalone_message")
     def test_parse_from_random_order(self, action_structure):
         # Create Eliot messages for given tree of actions and messages:
-        messages = ActionStructure.to_eliot(action_structure)
+        logger = MemoryLogger()
+        messages = ActionStructure.to_eliot(action_structure, logger)
 
         # Parse resulting message dicts in random order:
         order = range(len(messages))
@@ -83,7 +83,7 @@ class TaskTests(TestCase):
             task = task.add(messages[index])
 
         # Assert parsed structure matches input structure:
-        print action_structure, order, task
+        #print action_structure, order, task
         parsed_structure = ActionStructure.from_written(task.root())
         self.assertEqual(parsed_structure, action_structure,
                          "Order: {}, {} != {}".format(

--- a/eliot/tests/test_parse.py
+++ b/eliot/tests/test_parse.py
@@ -24,7 +24,7 @@ class ActionStructure(PClass):
         if isinstance(tree_or_message, list):
             return cls(
                 type=TYPES.example(),
-                children=[cls._from_tree(o) for o in tree_or_message])
+                children=[cls.from_tree(o) for o in tree_or_message])
         else:
             return tree_or_message
 
@@ -33,10 +33,11 @@ class ActionStructure(PClass):
         if isinstance(written, WrittenMessage):
             return written.as_dict()[MESSAGE_TYPE_FIELD]
         else:  # WrittenAction
+            if not written.end_message:# or written.end_message.as_dict()[MESSAGE_TYPE_FIELD]:
+                raise AssertionError("XXX ugh this is a bad check")
             return cls(
-                type=written.action_type(),
-                children=[cls.from_written(o) for o in written.children]
-                + [written.end_message])
+                type=written.action_type,
+                children=[cls.from_written(o) for o in written.children])
 
     @classmethod
     def to_eliot(cls, structure_or_message):
@@ -82,6 +83,8 @@ class TaskTests(TestCase):
             task = task.add(messages[index])
 
         # Assert parsed structure matches input structure:
+        print action_structure, order, task
         parsed_structure = ActionStructure.from_written(task.root())
         self.assertEqual(parsed_structure, action_structure,
-                         "Order: {}".format(order))
+                         "Order: {}, {} != {}".format(
+                             order, parsed_structure, action_structure))

--- a/eliot/tests/test_parse.py
+++ b/eliot/tests/test_parse.py
@@ -2,15 +2,81 @@
 Tests for L{eliot._parse}.
 """
 
-'''
-Basic idea for testing parsing:
+from unittest import TestCase
+from random import shuffle
 
-Create a tree of Eliot actions and messages (using Hypothesis stateful
-testing? Normal hypothesis tests?). Feed resulting messages into parser in
-random order. At the end we should get expected result.
+from hypothesis import strategies, strategy, example
 
-The key thought here is that if any random order is correct then the
-intermediate states must be correct too.
+from pyrsistent import PClass, field, pvector_field
 
-Additional coverage is likely needed that is specific to missing actions.
-'''
+from .. import start_action, Message
+from ..testing import capture_logging
+from .._parse import Task
+from .._message import WrittenMessage
+
+
+class StubAction(PClass):
+    type = field(type=unicode, mandatory=True)
+    children = pvector_field(("StubAction", unicode), mandatory=True)
+
+    @classmethod
+    def _from_tree(cls, tree_or_message):
+        if isinstance(tree_or_message, list):
+            return StubAction(
+                type=TYPES.example(),
+                children=[StubAction._from_tree(o) for o in tree_or_message])
+        else:
+            return tree_or_message
+
+    @classmethod
+    def from_written(cls, written):
+        if isinstance(written, WrittenMessage):
+            return written.message_type
+        else:  # WrittenAction
+            return StubAction(
+                type=written.action_type,
+                children=[StubAction.from_written(o) for o in written.children]
+                + [written.end_message])
+
+    @classmethod
+    def to_eliot(cls, stub_or_message):
+        if isinstance(stub_or_message, cls):
+            action = stub_or_message
+            with start_action(action_type=action.type):
+                for child in action.children:
+                    cls.to_eliot(child)
+        else:
+            Message.log(message_type=stub_or_message)
+
+
+TYPES = strategies.text(min_size=1, average_size=3, alphabet=u"CGAT")
+TASKS = strategies.recursive(
+    strategies.text(min_size=1, average_size=3, alphabet=u"CGAT"),
+    strategies.lists, max_leaves=5).map(StubAction.from_tree)
+
+
+class TaskTests(TestCase):
+    """
+    Tests for L{Task}.
+
+    Create a tree of Eliot actions and messages using Hypothesis. Feed
+    resulting messages into tree parser in random order. At the end we should
+    get expected result. The key idea here is that if any random order is
+    correct then the intermediate states must be correct too.
+
+    Additional coverage is then needed that is specific to the intermediate
+    states, i.e. missing messages.
+    """
+    @strategy(task_structure=TASKS)
+    @example(task_structure=u"standalone_message")
+    @example(task_structure=[])
+    @capture_logging(None)
+    def test_parse_from_random_order(self, logger, task_structure):
+        StubAction.to_eliot(task_structure)
+        messages = logger.messages
+        order = range(len(messages))
+        shuffle(order)
+        task = Task.from_messages([messages[i] for i in order])
+        parsed_structure = StubAction.from_written(task.root())
+        self.assertEqual(parsed_structure, task_structure,
+                         "Order: {}".format(order))

--- a/eliot/tests/test_parse.py
+++ b/eliot/tests/test_parse.py
@@ -15,6 +15,7 @@ from ..testing import MemoryLogger
 from .._parse import Task
 from .._message import WrittenMessage, MESSAGE_TYPE_FIELD, TASK_LEVEL_FIELD
 from .._action import FAILED_STATUS, ACTION_STATUS_FIELD, WrittenAction
+from .strategies import labels
 
 
 class ActionStructure(PClass):
@@ -66,21 +67,18 @@ class ActionStructure(PClass):
         return logger.messages
 
 
-TYPES = st.text(min_size=1, average_size=3, alphabet=u"CGAT")
-
-
 @st.composite
 def action_structures(draw):
     """
     A Hypothesis strategy that creates a tree of L{ActionStructure} and
     L{unicode}.
     """
-    tree = draw(st.recursive(TYPES, st.lists, max_leaves=50))
+    tree = draw(st.recursive(labels, st.lists, max_leaves=50))
 
     def to_structure(tree_or_message):
         if isinstance(tree_or_message, list):
             return ActionStructure(
-                type=draw(TYPES),
+                type=draw(labels),
                 failed=draw(st.booleans()),
                 children=[to_structure(o) for o in tree_or_message])
         else:

--- a/eliot/tests/test_parse.py
+++ b/eliot/tests/test_parse.py
@@ -92,8 +92,8 @@ class TaskTests(TestCase):
     def test_parse_from_random_order(self, structure_and_messages):
         action_structure, messages = structure_and_messages
 
-        task = Task.create(messages[0])
-        for message in messages[1:]:
+        task = Task()
+        for message in messages:
             task = task.add(message)
 
         # Assert parsed structure matches input structure:

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         # Struct-like objects:
         "characteristic",
         # Persistent objects for Python:
-        "pyrsistent >= 0.11.7",  # no segfaults please
+        "pyrsistent >= 0.11.8",  # version with multi-type pvector/pmap_field
     ],
     extras_require={
         "journald": [

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         # Struct-like objects:
         "characteristic",
         # Persistent objects for Python:
-        "pyrsistent",
+        "pyrsistent >= 0.11.7",  # no segfaults please
     ],
     extras_require={
         "journald": [


### PR DESCRIPTION
Part 1 out of 2 of parsing messages into a tree. This branch adds code which allows parsing messages with the same task UUID into a tree object, a `eliot._parse.Task`.

This builds on #227 which should be reviewed first.

Next step will be parsing unrelated messages into a forest, in #228.