### PR TITLE
Parse messages into a forest of Tasks

### DIFF
--- a/eliot/_parse.py
+++ b/eliot/_parse.py
@@ -132,12 +132,13 @@ class Parser(PClass):
 
     def add(self, message_dict):
         """
-        Update the L{} with a dictionary containing a serialized Eliot
+        Update the L{Parser} with a dictionary containing a serialized Eliot
         message.
 
         @param message_dict: Dictionary of serialized Eliot message.
 
-        @return: Tuple of (list of completed L{Task} instances, updated L{Parser}).
+        @return: Tuple of (list of completed L{Task} instances, updated
+            L{Parser}).
         """
         uuid = message_dict[TASK_UUID_FIELD]
         if uuid in self._tasks:

--- a/eliot/_parse.py
+++ b/eliot/_parse.py
@@ -158,7 +158,15 @@ class Parser(PClass):
 
     @classmethod
     def parse_stream(cls, iterable):
-        return
+        """
+        Parse a stream of messages into a stream of L{Task} instances.
+
+        :param iterable: An iterable of serialized Eliot message dictionaries.
+
+        :return: An iterable of parsed L{Task} instances. Remaining
+            incomplete L{Task} will be returned when the input stream is
+            exhausted.
+        """
         parser = Parser()
         for message_dict in iterable:
             completed, parser = parser.add(message_dict)

--- a/eliot/_parse.py
+++ b/eliot/_parse.py
@@ -154,6 +154,7 @@ class Parser(PClass):
         """
         @return: List of L{Task} that are not yet complete.
         """
+        return list(self._tasks.values())
 
     @classmethod
     def parse_stream(cls, iterable):

--- a/eliot/_parse.py
+++ b/eliot/_parse.py
@@ -118,3 +118,34 @@ class Task(PClass):
                     ["_completed"], lambda s: s.add(self._root_level))
             else:
                 return self._ensure_node_parents(written_message)
+
+
+class Parser(PClass):
+    """
+    Parse serialized Eliot messages into L{Task} instances.
+    """
+    def add(self, message_dict):
+        """
+        Update the L{} with a dictionary containing a serialized Eliot
+        message.
+
+        @param message_dict: Dictionary whose task UUID matches this one.
+
+        @return: Tuple of (list of completed L{Task} instances, updated L{Parser}).
+        """
+
+    def incomplete_tasks(self):
+        """
+        @return: List of L{Task} that are not yet complete.
+        """
+
+    @classmethod
+    def parse_stream(cls, iterable):
+        return
+        parser = Parser()
+        for message_dict in iterable:
+            completed, parser = parser.add(message_dict)
+            for task in completed:
+                yield task
+        for task in parser.incomplete_tasks():
+            yield task

--- a/eliot/_parse.py
+++ b/eliot/_parse.py
@@ -5,6 +5,8 @@ Parse a stream of serialized messages into a forest of
 
 from __future__ import unicode_literals
 
+from six import text_type as unicode
+
 from pyrsistent import PClass, pmap_field, pset_field, discard
 
 from ._message import WrittenMessage, TASK_UUID_FIELD

--- a/eliot/_parse.py
+++ b/eliot/_parse.py
@@ -129,7 +129,7 @@ class Parser(PClass):
         Update the L{} with a dictionary containing a serialized Eliot
         message.
 
-        @param message_dict: Dictionary whose task UUID matches this one.
+        @param message_dict: Dictionary of serialized Eliot message.
 
         @return: Tuple of (list of completed L{Task} instances, updated L{Parser}).
         """

--- a/eliot/tests/strategies.py
+++ b/eliot/tests/strategies.py
@@ -5,12 +5,11 @@ Hypothesis strategies for eliot.
 from __future__ import unicode_literals
 
 from functools import partial
-from uuid import UUID
+from uuid import uuid4
 
 from six import text_type as unicode
 
 from hypothesis.strategies import (
-    basic,
     builds,
     dictionaries,
     fixed_dictionaries,
@@ -51,7 +50,7 @@ labels = text(average_size=3, min_size=1, alphabet="CGAT")
 
 timestamps = floats(min_value=0)
 
-uuids = basic(generate=lambda r, _: unicode(UUID(int=r.getrandbits(128))))
+uuids = builds(lambda: unicode(uuid4()))
 
 message_core_dicts = fixed_dictionaries(
     dict(task_level=task_level_lists.map(pvector),

--- a/eliot/tests/test_parse.py
+++ b/eliot/tests/test_parse.py
@@ -224,3 +224,26 @@ class ParserTests(TestCase):
 
         self.assertItemsEqual(
             all_tasks, [parse_all(msgs) for msgs in all_messages])
+
+    @given(structure_and_messages=STRUCTURES_WITH_MESSAGES)
+    def test_incomplete_tasks(self, structure_and_messages):
+        """
+        Until a L{Task} is fully parsed, it is returned in
+        L{Parser.incomplete_tasks}.
+        """
+        _, messages = structure_and_messages
+        parser = Parser()
+        task = Task()
+        incomplete_matches = []
+        for message in messages[:-1]:
+            _, parser = parser.add(message)
+            task = task.add(message)
+            incomplete_matches.append(parser.incomplete_tasks() == [task])
+
+        task = task.add(messages[-1])
+        _, parser = parser.add(messages[-1])
+        self.assertEqual(
+            dict(incomplete_matches=incomplete_matches,
+                 final_incompleted=parser.incomplete_tasks()),
+            dict(incomplete_matches=[True] * (len(messages) - 1),
+                 final_incompleted=[]))

--- a/eliot/tests/test_parse.py
+++ b/eliot/tests/test_parse.py
@@ -194,15 +194,20 @@ class ParserTests(TestCase):
     Tests for L{Parser}.
     """
     @given(structure_and_messages1=STRUCTURES_WITH_MESSAGES,
-           structure_and_messages2=STRUCTURES_WITH_MESSAGES)
+           structure_and_messages2=STRUCTURES_WITH_MESSAGES,
+           structure_and_messages3=STRUCTURES_WITH_MESSAGES)
     def test_parse_into_tasks(self, structure_and_messages1,
-                              structure_and_messages2):
+                              structure_and_messages2,
+                              structure_and_messages3):
         """
         Adding messages to a L{Parser} parses them into a L{Task} instances.
         """
         _, messages1 = structure_and_messages1
         _, messages2 = structure_and_messages2
-        assume(messages1[0][TASK_UUID_FIELD] != messages2[0][TASK_UUID_FIELD])
+        _, messages3 = structure_and_messages3
+        all_messages = (messages1, messages2, messages3)
+        # Need unique UUIDs per task:
+        assume(len(set(m[0][TASK_UUID_FIELD] for m in all_messages)) == 3)
 
         def parse_all(messages):
             task = Task()
@@ -212,11 +217,10 @@ class ParserTests(TestCase):
 
         parser = Parser()
         all_tasks = []
-        for message in chain(*izip_longest(messages1, messages2)):
+        for message in chain(*izip_longest(*all_messages)):
             if message is not None:
                 completed_tasks, parser = parser.add(message)
                 all_tasks.extend(completed_tasks)
 
         self.assertItemsEqual(
-            all_tasks,
-            [parse_all(msgs) for msgs in (messages1, messages2)])
+            all_tasks, [parse_all(msgs) for msgs in all_messages])

--- a/eliot/tests/test_parse.py
+++ b/eliot/tests/test_parse.py
@@ -5,9 +5,10 @@ Tests for L{eliot._parse}.
 from __future__ import unicode_literals
 
 from unittest import TestCase
-from itertools import chain, izip_longest
+from itertools import chain
 
-from six import text_type as unicode
+from six import text_type as unicode, assertCountEqual
+from six.moves import zip_longest
 
 from hypothesis import strategies as st, given, assume
 
@@ -221,13 +222,13 @@ class ParserTests(TestCase):
 
         parser = Parser()
         all_tasks = []
-        for message in chain(*izip_longest(*all_messages)):
+        for message in chain(*zip_longest(*all_messages)):
             if message is not None:
                 completed_tasks, parser = parser.add(message)
                 all_tasks.extend(completed_tasks)
 
-        self.assertItemsEqual(
-            all_tasks, [parse_to_task(msgs) for msgs in all_messages])
+        assertCountEqual(
+            self, all_tasks, [parse_to_task(msgs) for msgs in all_messages])
 
     @given(structure_and_messages=STRUCTURES_WITH_MESSAGES)
     def test_incomplete_tasks(self, structure_and_messages):
@@ -275,7 +276,7 @@ class ParserTests(TestCase):
         all_messages = (messages1, messages2, messages3[:-1])
 
         all_tasks = list(Parser.parse_stream(
-            [m for m in chain(*izip_longest(*all_messages))
+            [m for m in chain(*zip_longest(*all_messages))
              if m is not None]))
-        self.assertItemsEqual(
-            all_tasks, [parse_to_task(msgs) for msgs in all_messages])
+        assertCountEqual(
+            self, all_tasks, [parse_to_task(msgs) for msgs in all_messages])

--- a/eliot/tests/test_parse.py
+++ b/eliot/tests/test_parse.py
@@ -149,6 +149,23 @@ class TaskTests(TestCase):
         parsed_structure = ActionStructure.from_written(task.root())
         self.assertEqual(parsed_structure, action_structure)
 
+    @given(structure_and_messages=STRUCTURES_WITH_MESSAGES)
+    def test_is_complete(self, structure_and_messages):
+        """
+        ``Task.is_complete()`` only returns true when all messages within the
+        tree have been delivered.
+        """
+        action_structure, messages = structure_and_messages
+
+        task = Task()
+        completed = []
+        for message in messages:
+            task = task.add(message)
+            completed.append(task.is_complete())
+
+        self.assertEqual(completed,
+                         [False for m in messages[:-1]] + [True])
+
     def test_parse_contents(self):
         """
         L{{Task.add}} parses the contents of the messages it receives.


### PR DESCRIPTION
Fixes #228.

1. Added concept of completeness to task-specific (==tree of actions parser) `Task`. A ``Task` is complete if all its messages have been parsed.
2. Added a new class `Parser` which parses messages into a forest of actions, i.e. multiple `Task` instances one per task UUID.
3. Added a higher-level API for parsing streams of messages.
4. Changed `hypothesis` strategy for generating UUIDs so that it generates them more randomly; previous implementation resulted in repeated UUIDs.